### PR TITLE
Fix cache strict look up bug and unify cache management

### DIFF
--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -2,9 +2,11 @@ package phonenumbers
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/theothertomelliott/go-must"
 )
 
 func TestParse(t *testing.T) {
@@ -1208,4 +1210,64 @@ func TestMergeLengths(t *testing.T) {
 			t.Errorf("[test %d:num] failed for l1: %v and l2: %v: %v != %v\n", i, tc.l1, tc.l2, tc.merged, merged)
 		}
 	}
+}
+
+func TestRegexCacheWrite(t *testing.T) {
+	pattern1 := "TestRegexCacheWrite"
+	if _, found1 := readFromRegexCache(pattern1); found1 {
+		t.Errorf("pattern |%v| is in the cache", pattern1)
+	}
+	regex1 := regexFor(pattern1)
+	cachedRegex1, found1 := readFromRegexCache(pattern1)
+	if !found1 {
+		t.Errorf("pattern |%v| is not in the cache", pattern1)
+	}
+	if regex1 != cachedRegex1 {
+		t.Error("expected the same instance, but got a different one")
+	}
+	pattern2 := pattern1 + "."
+	if _, found2 := readFromRegexCache(pattern2); found2 {
+		t.Errorf("pattern |%v| is in the cache", pattern2)
+	}
+}
+
+func TestRegexCacheRead(t *testing.T) {
+	pattern1 := "TestRegexCacheRead"
+	if _, found1 := readFromRegexCache(pattern1); found1 {
+		t.Errorf("pattern |%v| is in the cache", pattern1)
+	}
+	regex1 := regexp.MustCompile(pattern1)
+	writeToRegexCache(pattern1, regex1)
+	if cachedRegex1 := regexFor(pattern1); cachedRegex1 != regex1 {
+		t.Error("expected the same instance, but got a different one")
+	}
+	cachedRegex1, found1 := readFromRegexCache(pattern1)
+	if !found1 {
+		t.Errorf("pattern |%v| is not in the cache", pattern1)
+	}
+	if cachedRegex1 != regex1 {
+		t.Error("expected the same instance, but got a different one")
+	}
+	pattern2 := pattern1 + "."
+	if _, found2 := readFromRegexCache(pattern2); found2 {
+		t.Errorf("pattern |%v| is in the cache", pattern2)
+	}
+}
+
+func TestRegexCacheStrict(t *testing.T) {
+	const expectedResult = "(41) 3020-3445"
+	phoneToTest := &PhoneNumber{
+		CountryCode:    proto.Int32(55),
+		NationalNumber: proto.Uint64(4130203445),
+	}
+	firstRunResult := Format(phoneToTest, NATIONAL)
+	must.BeEqual(t, expectedResult, firstRunResult, "phone number formatting not as expected")
+	// This adds value to the regex cache that would break the following lookup if the regex-s
+	// in cache were not strict.
+	Format(&PhoneNumber{
+		CountryCode:    proto.Int32(973),
+		NationalNumber: proto.Uint64(17112724),
+	}, NATIONAL)
+	secondRunResult := Format(phoneToTest, NATIONAL)
+	must.BeEqual(t, expectedResult, secondRunResult, "phone number formatting not as expected")
 }


### PR DESCRIPTION
This fixes the look up in chooseFormattingPatternForNumber (previously, it used the non-strict version when looking up the pattern in the cache; yet, saved the strict one). That caused a very rare bug, where a certain order of look-ups would result in incorrect formatting.
TestRegexCacheStrict demonstrates the issue (using the values provided in the test in the same order would return wrong results in the existing version).