### PR TITLE
Fix staticcheck complaints

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -512,7 +512,7 @@ func setPossibleLengthsGeneralDesc(generalDesc *PhoneNumberDesc, metadataId stri
 	} else {
 		populatePossibleLengthSets([]*PhoneNumberDescE{data.ShortCode}, lengths, localOnlyLengths)
 		if len(localOnlyLengths) > 0 {
-			panic(fmt.Errorf("Found local-only lengths in short-number metadata"))
+			panic(fmt.Errorf("found local-only lengths in short-number metadata"))
 		}
 	}
 	setPossibleLengths(lengths, localOnlyLengths, nil, generalDesc)

--- a/cmd/buildmetadata/main.go
+++ b/cmd/buildmetadata/main.go
@@ -211,7 +211,7 @@ func writeIntStringArrayMap(path string, varName string, prefixMap map[int][]str
 	// we write our key / value pairs as a varint of the difference of the previous prefix
 	// and a uint16 of the value index
 	last := 0
-	intBuf := make([]byte, 6, 6)
+	intBuf := make([]byte, 6)
 	for _, key := range keys {
 		// first write our prefix
 		diff := key - last
@@ -369,7 +369,7 @@ func buildPrefixData(build *prefixBuild) {
 		// we write our prefix / value pairs as a varint of the difference of the previous prefix
 		// and a uint16 of the value index
 		last := 0
-		intBuf := make([]byte, 6, 6)
+		intBuf := make([]byte, 6)
 		for _, prefix := range prefixes {
 			value := mappings[prefix]
 			valueIntern := internMappings[value]

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -375,24 +375,24 @@ var (
 	VALID_PHONE_NUMBER_PATTERN = regexp.MustCompile(
 		"^(" + VALID_PHONE_NUMBER + "(?:" + EXTN_PATTERNS_FOR_PARSING + ")?)$")
 
-	NON_DIGITS_PATTERN = regexp.MustCompile("(\\D+)")
-	DIGITS_PATTERN     = regexp.MustCompile("(\\d+)")
+	NON_DIGITS_PATTERN = regexp.MustCompile(`(\D+)`)
+	DIGITS_PATTERN     = regexp.MustCompile(`(\d+)`)
 
 	// The FIRST_GROUP_PATTERN was originally set to $1 but there are some
 	// countries for which the first group is not used in the national
 	// pattern (e.g. Argentina) so the $1 group does not match correctly.
 	// Therefore, we use \d, so that the first group actually used in the
 	// pattern will be matched.
-	FIRST_GROUP_PATTERN = regexp.MustCompile("(\\$\\d)")
-	NP_PATTERN          = regexp.MustCompile("\\$NP")
-	FG_PATTERN          = regexp.MustCompile("\\$FG")
-	CC_PATTERN          = regexp.MustCompile("\\$CC")
+	FIRST_GROUP_PATTERN = regexp.MustCompile(`(\$\d)`)
+	NP_PATTERN          = regexp.MustCompile(`\$NP`)
+	FG_PATTERN          = regexp.MustCompile(`\$FG`)
+	CC_PATTERN          = regexp.MustCompile(`\$CC`)
 
 	// A pattern that is used to determine if the national prefix
 	// formatting rule has the first group only, i.e., does not start
 	// with the national prefix. Note that the pattern explicitly allows
 	// for unbalanced parentheses.
-	FIRST_GROUP_ONLY_PREFIX_PATTERN = regexp.MustCompile("\\(?\\$1\\)?")
+	FIRST_GROUP_ONLY_PREFIX_PATTERN = regexp.MustCompile(`\(?\$1\)?`)
 
 	REGION_CODE_FOR_NON_GEO_ENTITY = "001"
 )

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -2522,8 +2522,8 @@ func extractCountryCode(fullNumber, nationalNumber *Builder) int {
 	return 0
 }
 
-var ErrTooShortAfterIDD = errors.New("Phone number had an IDD, but " +
-	"after this was not long enough to be a viable phone number.")
+var ErrTooShortAfterIDD = errors.New("phone number had an IDD, but " +
+	"after this was not long enough to be a viable phone number")
 
 // Tries to extract a country calling code from a number. This method will
 // return zero if no country calling code is considered to be present.
@@ -2860,8 +2860,8 @@ func setItalianLeadingZerosForPhoneNumber(
 
 var (
 	ErrInvalidCountryCode = errors.New("invalid country code")
-	ErrNotANumber         = errors.New("The phone number supplied is not a number.")
-	ErrTooShortNSN        = errors.New("The string supplied is too short to be a phone number.")
+	ErrNotANumber         = errors.New("the phone number supplied is not a number")
+	ErrTooShortNSN        = errors.New("the string supplied is too short to be a phone number")
 )
 
 // Parses a string and fills up the phoneNumber. This method is the same
@@ -2988,7 +2988,7 @@ func parseHelper(
 	return nil
 }
 
-var ErrNumTooLong = errors.New("The string supplied is too long to be a phone number.")
+var ErrNumTooLong = errors.New("the string supplied is too long to be a phone number")
 
 // Converts numberToParse to a form that we can parse and write it to
 // nationalNumber if it is written in RFC3966; otherwise extract a possible

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -2390,7 +2390,7 @@ func testNumberLength(number string, metadata *PhoneMetadata, numberType PhoneNu
 	}
 
 	// We skip the first element; we've already checked it.
-	for _, l := range possibleLengths[1:len(possibleLengths)] {
+	for _, l := range possibleLengths[1:] {
 		if l == actualLength {
 			return IS_POSSIBLE
 		}
@@ -3289,10 +3289,10 @@ func init() {
 	}
 
 	// Create our sync.Onces for each of our languages for carriers
-	for lang, _ := range carrierMapData {
+	for lang := range carrierMapData {
 		carrierOnces[lang] = &sync.Once{}
 	}
-	for lang, _ := range geocodingMapData {
+	for lang := range geocodingMapData {
 		geocodingOnces[lang] = &sync.Once{}
 	}
 }

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -1528,7 +1528,6 @@ func FormatInOriginalFormat(number *PhoneNumber, regionCallingFrom string) strin
 		numFormatCopy.NationalPrefixFormattingRule = nil
 		var numberFormats = []*NumberFormat{numFormatCopy}
 		formattedNumber = FormatByPattern(number, NATIONAL, numberFormats)
-		break
 	}
 	rawInput = number.GetRawInput()
 	// If no digit is inserted/removed/modified as a result of our

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -768,10 +768,10 @@ func TestGetLengthOfGeographicalAreaCode(t *testing.T) {
 }
 
 func TestGetCountryMobileToken(t *testing.T) {
-	if "1" != GetCountryMobileToken(GetCountryCodeForRegion("MX")) {
+	if GetCountryMobileToken(GetCountryCodeForRegion("MX")) != "1" {
 		t.Error("Mexico should have a mobile token == \"1\"")
 	}
-	if "" != GetCountryMobileToken(GetCountryCodeForRegion("SE")) {
+	if GetCountryMobileToken(GetCountryCodeForRegion("SE")) != "" {
 		t.Error("Sweden should have a mobile token")
 	}
 }
@@ -838,13 +838,13 @@ func TestGetExampleNumberForNonGeoEntity(t *testing.T) {
 }
 
 func TestNormalizeDigitsOnly(t *testing.T) {
-	if "03456234" != NormalizeDigitsOnly("034-56&+a#234") {
+	if NormalizeDigitsOnly("034-56&+a#234") != "03456234" {
 		t.Errorf("didn't fully normalize digits only")
 	}
 }
 
 func TestNormalizeDiallableCharsOnly(t *testing.T) {
-	if "03*456+234" != normalizeDiallableCharsOnly("03*4-56&+a#234") {
+	if normalizeDiallableCharsOnly("03*4-56&+a#234") != "03*456+234" {
 		t.Error("did not correctly remove non-diallable characters")
 	}
 }

--- a/serialize.go
+++ b/serialize.go
@@ -32,7 +32,7 @@ func loadPrefixMap(data string) (*intStringMap, error) {
 	}
 
 	// then our values
-	valueBytes := make([]byte, valueSize, valueSize)
+	valueBytes := make([]byte, valueSize)
 	n, err := reader.Read(valueBytes)
 	if uint32(n) < valueSize {
 		return nil, fmt.Errorf("unable to read all values: %v", err)
@@ -103,7 +103,7 @@ func loadIntStringArrayMap(data string) (*intStringArrayMap, error) {
 	}
 
 	// then our values
-	valueBytes := make([]byte, valueSize, valueSize)
+	valueBytes := make([]byte, valueSize)
 	n, err := reader.Read(valueBytes)
 	if uint32(n) < valueSize {
 		return nil, fmt.Errorf("unable to read all values: %v", err)
@@ -136,7 +136,7 @@ func loadIntStringArrayMap(data string) (*intStringArrayMap, error) {
 			return nil, err
 		}
 
-		keyValues := make([]string, valueCount, valueCount)
+		keyValues := make([]string, valueCount)
 		for i := 0; i < int(valueCount); i++ {
 			var valueIntern uint16
 			err = binary.Read(reader, binary.LittleEndian, &valueIntern)


### PR DESCRIPTION
While using this library I came across error strings starting uppercase characters and punctuation, so 
I fixed all `staticcheck` complaints except unused functions.