### PR TITLE
chore: separate go.mod and go.sum for tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 build:
 	mkdir -p functions
-	go get ./...
-	go build -ldflags "-X main.Version=`git describe --tags`" -o functions/phoneserver ./cmd/phoneserver
+	cd cmd/phoneserver
+	go build -ldflags "-X main.Version=`git describe --tags`" -o ../../functions/phoneserver .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-phonenumbers  [![Build Status](https://travis-ci.org/nyaruka/phonenumbers.svg?branch=master)](https://travis-ci.org/nyaruka/phonenumbers) 
+phonenumbers [![Build Status](https://travis-ci.org/nyaruka/phonenumbers.svg?branch=master)](https://travis-ci.org/nyaruka/phonenumbers)
 [![GoDoc](https://godoc.org/github.com/nyaruka/phonenumbers?status.svg)](https://godoc.org/github.com/nyaruka/phonenumbers)
 ==============
 
@@ -10,13 +10,11 @@ This fork fixes quite a few bugs and more closely follows the official Java impl
 
 This library is used daily in production for parsing and validation of numbers across the world, so is well maintained. Please open an issue if you encounter any problems, we'll do our best to address them.
 
-Version Numbers
-=======
+# Version Numbers
 
 As we don't want to bump our major semantic version number in step with the upstream library, we use independent version numbers than the Google libphonenumber repo. The release notes will mention what version of the metadata a release was built against.
 
-Usage
-========
+# Usage
 
 ```go
 // parse our phone number
@@ -26,8 +24,7 @@ num, err := phonenumbers.Parse("6502530000", "US")
 formattedNum := phonenumbers.Format(num, phonenumbers.NATIONAL)
 ```
 
-Rebuilding Metadata and Maps
-===============================
+# Rebuilding Metadata and Maps
 
 The `buildmetadata` command will fetch the latest XML file from the official Google repo and rebuild the go source files containing all the territory metadata, timezone and region maps. (you will need `svn` installed on your path)
 
@@ -44,7 +41,6 @@ It will rebuild the following files:
 `prefix_to_timezone_bin.go` - contains the information needed to map a phone number prefix to a city or region
 
 ```bash
-% go get github.com/nyaruka/phonenumbers
-% go install github.com/nyaruka/phonenumbers/cmd/buildmetadata
+% cd cmd/buildmetadata && go install . && cd -
 % $GOPATH/bin/buildmetadata
 ```

--- a/cmd/phoneparser/go.mod
+++ b/cmd/phoneparser/go.mod
@@ -1,0 +1,7 @@
+module github.com/nyaruka/phonenumbers/cmd/phoneparser
+
+go 1.12
+
+replace github.com/nyaruka/phonenumbers => ../../
+
+require github.com/nyaruka/phonenumbers v0.0.0-00010101000000-000000000000

--- a/cmd/phoneparser/go.sum
+++ b/cmd/phoneparser/go.sum
@@ -1,0 +1,7 @@
+github.com/aws/aws-lambda-go v1.8.1/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/cmd/phoneserver/go.mod
+++ b/cmd/phoneserver/go.mod
@@ -1,0 +1,9 @@
+module github.com/nyaruka/phonenumbers/cmd/phoneserver
+
+go 1.12
+
+replace github.com/nyaruka/phonenumbers => ../../
+
+require (
+	github.com/aws/aws-lambda-go v1.13.1
+)

--- a/cmd/phoneserver/go.mod
+++ b/cmd/phoneserver/go.mod
@@ -6,4 +6,5 @@ replace github.com/nyaruka/phonenumbers => ../../
 
 require (
 	github.com/aws/aws-lambda-go v1.13.1
+	github.com/nyaruka/phonenumbers v0.0.0-00010101000000-000000000000
 )

--- a/cmd/phoneserver/go.sum
+++ b/cmd/phoneserver/go.sum
@@ -1,0 +1,13 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/aws/aws-lambda-go v1.8.1/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
+github.com/aws/aws-lambda-go v1.13.1 h1:qVIOD3UrEUo4amwgEBu6AI0CfnBsp71XJEYU05RbQ1k=
+github.com/aws/aws-lambda-go v1.13.1/go.mod h1:z4ywteZ5WwbIEzG0tXizIAUlUwkTNNknX4upd5Z5XJM=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module github.com/nyaruka/phonenumbers
 
-require (
-	github.com/aws/aws-lambda-go v1.8.1
-	github.com/golang/protobuf v1.3.2
-	github.com/stretchr/testify v1.3.0 // indirect
-)
+require github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,2 @@
-github.com/aws/aws-lambda-go v1.8.1 h1:nHBpP6XC30bwF6qWKrw/BrK2A8i4GKmSZzajTBIJS4A=
-github.com/aws/aws-lambda-go v1.8.1/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
In order to minimize transitive dependencies tools got their separate `go.mod` and `go.sum` files.
This removes `github.com/aws/aws-lambda-go` dependency from root package.