### PR TITLE
Fix formatting issues and add test cases

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -1415,20 +1415,8 @@ func FormatOutOfCountryCallingNumber(
 	maybeAppendFormattedExtension(number, metadataForRegion, INTERNATIONAL,
 		formattedNumber)
 	if len(internationalPrefixForFormatting) > 0 {
-		formattedBytes := formattedNumber.Bytes()
-		formattedBytes = append([]byte(" "), formattedBytes...)
-		// we know countryCallingCode is really an int32
-		intBuf := []byte{
-			byte(countryCallingCode >> 24),
-			byte(countryCallingCode >> 16),
-			byte(countryCallingCode >> 8),
-			byte(countryCallingCode),
-		}
-		formattedBytes = append(intBuf, formattedBytes...)
-		formattedBytes = append([]byte(" "), formattedBytes...)
-		formattedBytes = append(
-			[]byte(internationalPrefixForFormatting), formattedBytes...)
-		return string(formattedBytes)
+		formattedNumber.InsertString(0, internationalPrefixForFormatting + " " +
+			strconv.Itoa(countryCallingCode) + " ")
 	} else {
 		prefixNumberWithCountryCallingCode(
 			countryCallingCode, INTERNATIONAL, formattedNumber)
@@ -1682,20 +1670,8 @@ func FormatOutOfCountryKeepingAlphaChars(
 	maybeAppendFormattedExtension(number, metadataForRegion,
 		INTERNATIONAL, formattedNumber)
 	if len(internationalPrefixForFormatting) > 0 {
-		formattedBytes := append([]byte(" "), formattedNumber.Bytes()...)
-		// we know countryCode is really an int32
-		intBuf := []byte{
-			byte(countryCode >> 24),
-			byte(countryCode >> 16),
-			byte(countryCode >> 8),
-			byte(countryCode),
-		}
-		formattedBytes = append(intBuf, formattedBytes...)
-		formattedBytes = append([]byte(" "), formattedBytes...)
-		formattedBytes = append(
-			[]byte(internationalPrefixForFormatting), formattedBytes...)
-
-		formattedNumber = NewBuilder(formattedBytes)
+		formattedNumber.InsertString(0, internationalPrefixForFormatting + " " +
+			strconv.Itoa(countryCode) + " ")
 	} else {
 		// Invalid region entered as country-calling-from (so no metadata
 		// was found for it) or the region chosen has multiple international

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -1523,7 +1523,7 @@ func FormatInOriginalFormat(number *PhoneNumber, regionCallingFrom string) strin
 			break
 		}
 		// Otherwise, we need to remove the national prefix from our output.
-		var numFormatCopy *NumberFormat
+		numFormatCopy := &NumberFormat{}
 		proto.Merge(numFormatCopy, formatRule)
 		numFormatCopy.NationalPrefixFormattingRule = nil
 		var numberFormats = []*NumberFormat{numFormatCopy}
@@ -1645,7 +1645,7 @@ func FormatOutOfCountryKeepingAlphaChars(
 			// If no pattern above is matched, we format the original input.
 			return rawInput
 		}
-		var newFormat *NumberFormat
+		newFormat := &NumberFormat{}
 		proto.Merge(newFormat, formattingPattern)
 		// The first group is the first group of digits that the user
 		// wrote together.
@@ -2469,7 +2469,7 @@ func TruncateTooLongNumber(number *PhoneNumber) bool {
 	if IsValidNumber(number) {
 		return true
 	}
-	var numberCopy *PhoneNumber
+	numberCopy := &PhoneNumber{}
 	proto.Merge(numberCopy, number)
 	nationalNumber := number.GetNationalNumber()
 	nationalNumber /= 10

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -1486,6 +1486,7 @@ func FormatInOriginalFormat(number *PhoneNumber, regionCallingFrom string) strin
 		if rawInputContainsNationalPrefix(rawInput, nationalPrefix, regionCode) {
 			// If so, we can safely return the national format.
 			formattedNumber = nationalFormat
+			break
 		}
 		// Metadata cannot be null here because GetNddPrefixForRegion()
 		// (above) returns null if there is no metadata for the region.

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -447,6 +447,45 @@ func TestIsPossibleNumberWithReason(t *testing.T) {
 	}
 }
 
+func TestTruncateTooLongNumber(t *testing.T) {
+	var tests = []struct {
+		country int
+		in      uint64
+		out     uint64
+		res     bool
+	}{
+		{
+			country: 1,
+			in:      80055501234,
+			out:     8005550123,
+			res:     true,
+		}, {
+			country: 1,
+			in:      8005550123,
+			out:     8005550123,
+			res:     true,
+		}, {
+			country: 1,
+			in:      800555012,
+			out:     800555012,
+			res:     false,
+		},
+	}
+
+	for i, test := range tests {
+		num := &PhoneNumber{}
+		num.CountryCode = proto.Int(test.country)
+		num.NationalNumber = proto.Uint64(test.in)
+		res := TruncateTooLongNumber(num)
+		if res != test.res {
+			t.Errorf("[test %d:res] failed %t != %t\n", i, res, test.res)
+		}
+		if *num.NationalNumber != test.out {
+			t.Errorf("[test %d:num] failed % d!= %d\n", i, *num.NationalNumber, test.out)
+		}
+	}
+}
+
 func TestFormat(t *testing.T) {
 	// useful link for validating against official lib:
 	// http://libphonenumber.appspot.com/phonenumberparser?number=019+3286+9755&country=GB

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -714,6 +714,36 @@ func TestFormatOutOfCountryCallingNumber(t *testing.T) {
 	}
 }
 
+func TestFormatOutOfCountryKeepingAlphaChars(t *testing.T) {
+	var tests = []struct {
+		in     string
+		exp    string
+		region string
+		frmt   PhoneNumberFormat
+	}{
+		{
+			in:     "+1 800 six-flag",
+			region: "US",
+			exp:    "1 800 SIX-FLAG",
+		}, {
+			in:     "+1 800 six-flag",
+			region: "CH",
+			exp:    "00 1 800 SIX-FLAG",
+		},
+	}
+
+	for i, test := range tests {
+		num, err := ParseAndKeepRawInput(test.in, test.region)
+		if err != nil {
+			t.Errorf("[test %d] failed: should be able to parse, err:%v\n", i, err)
+		}
+		got := FormatOutOfCountryKeepingAlphaChars(num, test.region)
+		if got != test.exp {
+			t.Errorf("[test %d:fmt] failed %s != %s\n", i, got, test.exp)
+		}
+	}
+}
+
 func TestSetItalianLeadinZerosForPhoneNumber(t *testing.T) {
 	var tests = []struct {
 		num          string

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -668,6 +668,52 @@ func TestFormatInOriginalFormat(t *testing.T) {
 	}
 }
 
+func TestFormatOutOfCountryCallingNumber(t *testing.T) {
+	var tests = []struct {
+		in     string
+		exp    string
+		region string
+		frmt   PhoneNumberFormat
+	}{
+		{
+			in:     "+16505551234",
+			region: "US",
+			exp:    "1 (650) 555-1234",
+		}, {
+			in:     "+16505551234",
+			region: "CA",
+			exp:    "1 (650) 555-1234",
+		}, {
+			in:     "+16505551234",
+			region: "CH",
+			exp:    "00 1 650-555-1234",
+		}, {
+			in:     "+16505551234",
+			region: "ZZ",
+			exp:    "+1 650-555-1234",
+		}, {
+			in:	"+4911234",
+			region:	"US",
+			exp:	"011 49 11234",
+		}, {
+			in:	"+4911234",
+			region:	"DE",
+			exp:	"11234",
+		},
+	}
+
+	for i, test := range tests {
+		num, err := Parse(test.in, test.region)
+		if err != nil {
+			t.Errorf("[test %d] failed: should be able to parse, err:%v\n", i, err)
+		}
+		got := FormatOutOfCountryCallingNumber(num, test.region)
+		if got != test.exp {
+			t.Errorf("[test %d:fmt] failed %s != %s\n", i, got, test.exp)
+		}
+	}
+}
+
 func TestSetItalianLeadinZerosForPhoneNumber(t *testing.T) {
 	var tests = []struct {
 		num          string

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -579,6 +579,56 @@ func TestFormatByPattern(t *testing.T) {
 	}
 }
 
+func TestFormatInOriginalFormat(t *testing.T) {
+	var tests = []struct {
+		in     string
+		exp    string
+		region string
+		frmt   PhoneNumberFormat
+	}{
+		{
+			in:     "0987654321",
+			region: "DE",
+			exp:    "09876 54321",
+		}, {
+			in:     "0049987654321",
+			region: "CH",
+			exp:    "00 49 9876 54321",
+		}, {
+			in:     "+49987654321",
+			region: "DE",
+			exp:    "+49 9876 54321",
+		}, {
+			in:     "49987654321",
+			region: "DE",
+			exp:    "49 9876 54321",
+		}, {
+			in:     "6463752545",
+			region: "US",
+			exp:    "(646) 375-2545",
+		}, {
+			in:     "3752545",
+			region: "US",
+			exp:    "375-2545",
+		}, {
+			in:	"011420245646734",
+			region:	"US",
+			exp:	"011 420 245 646 734",
+		},
+	}
+
+	for i, test := range tests {
+		num, err := ParseAndKeepRawInput(test.in, test.region)
+		if err != nil {
+			t.Errorf("[test %d] failed: should be able to parse, err:%v\n", i, err)
+		}
+		got := FormatInOriginalFormat(num, test.region)
+		if got != test.exp {
+			t.Errorf("[test %d:fmt] failed %s != %s\n", i, got, test.exp)
+		}
+	}
+}
+
 func TestSetItalianLeadinZerosForPhoneNumber(t *testing.T) {
 	var tests = []struct {
 		num          string


### PR DESCRIPTION
This fixes the following issues:
- panics due to calling `proto.Merge` with nil destination (#39)
- missing `break` in `FormatInOriginalFormat` which prevented formatting of numbers with national prefix
- wrong country code formatting in `FormatOutOfCountryCallingNumber` and `FormatOutOfCountryKeepingAlphaChars` (instead of proper string conversion, the raw bytes of the country code integer were written to the output)

This also adds some test cases for all affected functions.