### PR TITLE
Fix regex func

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -2582,11 +2582,10 @@ func maybeExtractCountryCode(
 			// keep that instead.
 			finds := validNumberPattern.FindAllString(fullNumber.String(), -1)
 
-			ok1 := len(finds) != 0 && fullNumber.String() == finds[0]
-			ok2 := validNumberPattern.MatchString(potentialNationalNumber.String())
-			ok3 := testNumberLength(fullNumber.String(), defaultRegionMetadata, UNKNOWN) == TOO_LONG
-
-			if (ok1 && ok2) || ok3 {
+			cond := (len(finds) != 0 && fullNumber.String() == finds[0] &&
+				validNumberPattern.MatchString(potentialNationalNumber.String())) ||
+				testNumberLength(fullNumber.String(), defaultRegionMetadata, UNKNOWN) == TOO_LONG
+			if cond {
 				nationalNumber.Write(potentialNationalNumber.Bytes())
 				if keepRawInput {
 					val := PhoneNumber_FROM_NUMBER_WITHOUT_PLUS_SIGN

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -2580,9 +2580,13 @@ func maybeExtractCountryCode(
 			// if it was too long before, we consider the number with
 			// the country calling code stripped to be a better result and
 			// keep that instead.
-			if (!validNumberPattern.MatchString(fullNumber.String()) &&
-				validNumberPattern.MatchString(potentialNationalNumber.String())) ||
-				testNumberLength(fullNumber.String(), defaultRegionMetadata, UNKNOWN) == TOO_LONG {
+			finds := validNumberPattern.FindAllString(fullNumber.String(), -1)
+
+			ok1 := len(finds) != 0 && fullNumber.String() == finds[0]
+			ok2 := validNumberPattern.MatchString(potentialNationalNumber.String())
+			ok3 := testNumberLength(fullNumber.String(), defaultRegionMetadata, UNKNOWN) == TOO_LONG
+
+			if (ok1 && ok2) || ok3 {
 				nationalNumber.Write(potentialNationalNumber.Bytes())
 				if keepRawInput {
 					val := PhoneNumber_FROM_NUMBER_WITHOUT_PLUS_SIGN

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -672,7 +672,7 @@ func TestFormatInOriginalFormat(t *testing.T) {
 		}, {
 			in:     "49987654321",
 			region: "DE",
-			exp:    "49 9876 54321",
+			exp:    "4998 7654321",
 		}, {
 			in:     "6463752545",
 			region: "US",

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -79,7 +79,6 @@ func TestParse(t *testing.T) {
 		if err != test.err {
 			t.Errorf("[test %d:err] failed: %v != %v\n", i, err, test.err)
 		}
-		fmt.Println(GetRegionCodeForNumber(num))
 		if num.GetNationalNumber() != test.expectedNum {
 			t.Errorf("[test %d:num] failed: %v != %v\n", i, num.GetNationalNumber(), test.expectedNum)
 		}
@@ -1303,8 +1302,11 @@ func TestParsing(t *testing.T) {
 		{"+62877747666", "", "+62877747666"},
 		{"0877747666", "ID", "+62877747666"},
 		{"07531669965", "GB", "+447531669965"},
+		{"447531669965", "GB", "+447531669965"},
 		{"+22658125926", "", "+22658125926"},
 		{"+2203693200", "", "+2203693200"},
+		{"0877747666", "ID", "+62877747666"},
+		{"62816640000", "ID", "+62816640000"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Hi, we've encountered a problem with a phone from Indonesia (`62816640000` to be exact) when we tried to get a national number.

After verification this phone with a JS version (can be checked here, on the latest master https://rawgit.com/googlei18n/libphonenumber/master/javascript/i18n/phonenumbers/demo-compiled.html) we found that Go versions return national number with a country code (when it shouldn't).

```
phone: 62816640000
countyCode: ID

national number:
  Go: 62816640000
  JS: 816640000
```

The problem lies in a regular expression, 'cause it used slightly in a different way compared to JS. As you can see here [google/libphonenumber on the current master (v8.12.13)](https://github.com/google/libphonenumber/blob/67501b51d69049ef6270edfd9f88e49ff53222e9/javascript/i18n/phonenumbers/phonenumberutil.js#L4639) it checks that some group was found AND it equals to the whole string.

While in Go it's a simple match [nyaruka/phonenumbers on the current master (v1.0.59](https://github.com/nyaruka/phonenumbers/blob/a5776ac9657d930a5f974ef2b5c91e6847bc7b36/phonenumbers.go#L2583) (and Go docs confirms this https://pkg.go.dev/regexp#Regexp.MatchString).

After fixing this regex step, we've encountered a failing test (`TestFormatInOriginalFormat`) for `49987654321` `DE` and after another comparison to the JS we found another difference, instead of `49 9876 54321` should be `4998 7654321`.

Thank you. CC: @papisz 