### PR TITLE
Add MaybeSeparatePhoneFromExtension helper function

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -2719,6 +2719,38 @@ func maybeStripNationalPrefixAndCarrierCode(
 	return false
 }
 
+// MaybeSeparateExtensionFromPhone will extract any extension (as in, the part
+// of the number dialled after the call is connected, usually indicated with
+// extn, ext, x or similar) from the end of the number and returns it along
+// with the proceeding phone number. The phone number will maintain its
+// original formatting including alpha characters.
+func MaybeSeparateExtensionFromPhone(rawPhone string) (phoneNumber string, extension string) {
+	phoneNumber, extWithSeparator := splitAtExtensionSeparator(rawPhone)
+	if !isViablePhoneNumber(phoneNumber) || extWithSeparator == "" {
+		return rawPhone, ""
+	}
+	extension = removeLeadingExtensionSeparator(extWithSeparator)
+	return phoneNumber, extension
+}
+
+func splitAtExtensionSeparator(rawPhone string) (phoneNumber string, extWithSeparator string) {
+	ind := EXTN_PATTERN.FindStringIndex(rawPhone)
+	if len(ind) == 0 {
+		return rawPhone, ""
+	}
+	return rawPhone[0:ind[0]], rawPhone[ind[0]:]
+}
+
+func removeLeadingExtensionSeparator(extWithSeparator string) string {
+	matches := EXTN_PATTERN.FindStringSubmatch(extWithSeparator)
+	for _, extension := range matches[1:] {
+		if len(extension) > 0 {
+			return extension
+		}
+	}
+	return ""
+}
+
 // Strips any extension (as in, the part of the number dialled after the
 // call is connected, usually indicated with extn, ext, x or similar) from
 // the end of the number, and returns it.

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -1520,6 +1520,93 @@ func TestMaybeStripExtension(t *testing.T) {
 	}
 }
 
+func TestMaybeSeparateExtensionFromPhone(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawPhone  string
+		wantPhone string
+		wantExt   string
+	}{
+		{
+			name:      "Blank",
+			rawPhone:  "",
+			wantPhone: "",
+			wantExt:   "",
+		},
+		{
+			name:      "Number only",
+			rawPhone:  "+1 306-555-1234",
+			wantPhone: "+1 306-555-1234",
+			wantExt:   "",
+		},
+		{
+			name:      "Local phone",
+			rawPhone:  "555-1234",
+			wantPhone: "555-1234",
+			wantExt:   "",
+		},
+		{
+			name:      "Local phone with ext",
+			rawPhone:  "555-1234 x 78",
+			wantPhone: "555-1234",
+			wantExt:   "78",
+		},
+		{
+			name:      "Wait separator",
+			rawPhone:  "+1 306-555-1234;78",
+			wantPhone: "+1 306-555-1234",
+			wantExt:   "78",
+		},
+		{
+			name:      "Pause separator",
+			rawPhone:  "+1 306-555-1234,78",
+			wantPhone: "+1 306-555-1234",
+			wantExt:   "78",
+		},
+		{
+			name:      "Extra space separator",
+			rawPhone:  "+1 306-555-1234   ,  78",
+			wantPhone: "+1 306-555-1234",
+			wantExt:   "78",
+		},
+		{
+			name:      "ext. separator",
+			rawPhone:  "+1 306-555-1234 ext. 78",
+			wantPhone: "+1 306-555-1234",
+			wantExt:   "78",
+		},
+		{
+			name:      "# separator",
+			rawPhone:  "+1 306-555-1234 #78",
+			wantPhone: "+1 306-555-1234",
+			wantExt:   "78",
+		},
+		{
+			name:      "RFC3966",
+			rawPhone:  "+1 306-555-1234;ext=78",
+			wantPhone: "+1 306-555-1234",
+			wantExt:   "78",
+		},
+		{
+			name:      "Vanity phone number",
+			rawPhone:  "+1 800-Go-Green #78",
+			wantPhone: "+1 800-Go-Green",
+			wantExt:   "78",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := MaybeSeparateExtensionFromPhone(tt.rawPhone)
+			if got != tt.wantPhone {
+				t.Errorf("Phone got = %v, want %v", got, tt.wantPhone)
+			}
+			if got1 != tt.wantExt {
+				t.Errorf("Extension got = %v, want %v", got1, tt.wantExt)
+			}
+		})
+	}
+}
+
 func TestGetSupportedCallingCodes(t *testing.T) {
 	var tests = []struct {
 		code    int


### PR DESCRIPTION
I was looking for a way to separate the extension from the phone number without affecting the formatting of the phone number. The closest that I found was `maybeStripExtension` so I wrote a new function for myself. 

Do you have any interest in adding it to your project? 
I'd be happy to adjust it if you have naming conventions that you would like followed. 