### PR TITLE
Fix slice out of bounds in GetTimezonesForPrefix

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -3,7 +3,6 @@ package phonenumbers
 import (
 	"errors"
 	fmt "fmt"
-	math "math"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -3328,7 +3327,11 @@ func GetTimezonesForPrefix(number string) ([]string, error) {
 	// strip any leading +
 	number = strings.TrimLeft(number, "+")
 
-	matchLength := int(math.Min(float64(timezoneMap.MaxLength), float64(len(number))))
+	matchLength := len(number) // maxLength: min( len(number), timezoneMap.MaxLength )
+	if matchLength > timezoneMap.MaxLength {
+		matchLength = timezoneMap.MaxLength
+	}
+
 	for i := matchLength; i > 0; i-- {
 		index, err := strconv.Atoi(number[0:i])
 		if err != nil {

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -3,6 +3,7 @@ package phonenumbers
 import (
 	"errors"
 	fmt "fmt"
+	math "math"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -3327,7 +3328,8 @@ func GetTimezonesForPrefix(number string) ([]string, error) {
 	// strip any leading +
 	number = strings.TrimLeft(number, "+")
 
-	for i := timezoneMap.MaxLength; i > 0; i-- {
+	matchLength := int(math.Min(float64(timezoneMap.MaxLength), float64(len(number))))
+	for i := matchLength; i > 0; i-- {
 		index, err := strconv.Atoi(number[0:i])
 		if err != nil {
 			return nil, err

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -933,8 +933,8 @@ type testCase struct {
 }
 
 type timeZonesTestCases struct {
-	num              string
-	expectedTimeZone string
+	num               string
+	expectedTimeZones []string
 }
 
 func runTestBatch(t *testing.T, tests []testCase) {
@@ -1138,70 +1138,94 @@ func TestParsing(t *testing.T) {
 func TestGetTimeZonesForPrefix(t *testing.T) {
 	tests := []timeZonesTestCases{
 		{
-			num:              "+442073238299",
-			expectedTimeZone: "Europe/London",
+			num:               "+442073238299",
+			expectedTimeZones: []string{"Europe/London"},
 		},
 		{
-			num:              "+61491570156",
-			expectedTimeZone: "Australia/Sydney",
+			num:               "+61491570156",
+			expectedTimeZones: []string{"Australia/Sydney"},
 		},
 		{
-			num:              "+61255501234",
-			expectedTimeZone: "Australia/Sydney",
+			num:               "+61255501234",
+			expectedTimeZones: []string{"Australia/Sydney"},
 		},
 		{
-			num:              "+12067798181",
-			expectedTimeZone: "America/Los_Angeles",
+			num:               "+12067798181",
+			expectedTimeZones: []string{"America/Los_Angeles"},
 		},
 		{
-			num:              "+390399123456",
-			expectedTimeZone: "Europe/Rome",
+			num:               "+390399123456",
+			expectedTimeZones: []string{"Europe/Rome"},
 		},
 		{
-			num:              "+541151123456",
-			expectedTimeZone: "America/Buenos_Aires",
+			num:               "+541151123456",
+			expectedTimeZones: []string{"America/Buenos_Aires"},
 		},
 		{
-			num:              "+15167706076",
-			expectedTimeZone: "America/New_York",
+			num:               "+15167706076",
+			expectedTimeZones: []string{"America/New_York"},
 		},
 		{
-			num:              "+917999999543",
-			expectedTimeZone: "Asia/Calcutta",
+			num:               "+917999999543",
+			expectedTimeZones: []string{"Asia/Calcutta"},
 		},
 		{
-			num:              "+540111561234567",
-			expectedTimeZone: "America/Buenos_Aires",
+			num:               "+540111561234567",
+			expectedTimeZones: []string{"America/Buenos_Aires"},
 		},
 		{
-			num:              "+18504320800",
-			expectedTimeZone: "America/Chicago",
+			num:               "+18504320800",
+			expectedTimeZones: []string{"America/Chicago"},
 		},
 		{
-			num:              "+14079395277",
-			expectedTimeZone: "America/New_York",
+			num:               "+14079395277",
+			expectedTimeZones: []string{"America/New_York"},
 		},
 		{
-			num:              "+18508632167",
-			expectedTimeZone: "America/Chicago",
+			num:               "+18508632167",
+			expectedTimeZones: []string{"America/Chicago"},
 		},
 		{
-			num:              "+40213158207",
-			expectedTimeZone: "Europe/Bucharest",
+			num:               "+40213158207",
+			expectedTimeZones: []string{"Europe/Bucharest"},
 		},
 		// UTC +5:45
 		{
-			num:              "+97714240520",
-			expectedTimeZone: "Asia/Katmandu",
+			num:               "+97714240520",
+			expectedTimeZones: []string{"Asia/Katmandu"},
 		},
 		// UTC -3:30
 		{
-			num:              "+17097264534",
-			expectedTimeZone: "America/St_Johns",
+			num:               "+17097264534",
+			expectedTimeZones: []string{"America/St_Johns"},
 		},
 		{
-			num:              "0000000000",
-			expectedTimeZone: "Etc/Unknown",
+			num:               "0000000000",
+			expectedTimeZones: []string{"Etc/Unknown"},
+		},
+		{
+			num:               "+31112",
+			expectedTimeZones: []string{"Europe/Amsterdam"},
+		},
+		{
+			num:               "+6837000",
+			expectedTimeZones: []string{"Pacific/Niue"},
+		},
+		{
+			num: "+1911",
+			expectedTimeZones: []string{
+				"America/Adak", "America/Anchorage", "America/Anguilla", "America/Antigua",
+				"America/Barbados", "America/Boise", "America/Cayman", "America/Chicago",
+				"America/Denver", "America/Dominica", "America/Edmonton", "America/Fort_Nelson",
+				"America/Grand_Turk", "America/Grenada", "America/Halifax", "America/Jamaica",
+				"America/Juneau", "America/Los_Angeles", "America/Lower_Princes", "America/Montserrat",
+				"America/Nassau", "America/New_York", "America/North_Dakota/Center",
+				"America/Phoenix", "America/Port_of_Spain", "America/Puerto_Rico",
+				"America/Regina", "America/Santo_Domingo", "America/St_Johns", "America/St_Kitts",
+				"America/St_Lucia", "America/St_Thomas", "America/St_Vincent", "America/Toronto",
+				"America/Tortola", "America/Vancouver", "America/Winnipeg", "Atlantic/Bermuda",
+				"Pacific/Guam", "Pacific/Honolulu", "Pacific/Pago_Pago", "Pacific/Saipan",
+			},
 		},
 	}
 
@@ -1215,8 +1239,8 @@ func TestGetTimeZonesForPrefix(t *testing.T) {
 			t.Errorf("Expected at least 1 timezone.")
 		}
 
-		if timeZones[0] != test.expectedTimeZone {
-			t.Errorf("Expected '%s', got '%s' for '%s'", test.expectedTimeZone, timeZones[0], test.num)
+		if !reflect.DeepEqual(timeZones, test.expectedTimeZones) {
+			t.Errorf("Expected '%v', got '%v' for '%s'", test.expectedTimeZones, timeZones, test.num)
 		}
 
 		num, err := Parse(test.num, "")
@@ -1233,8 +1257,8 @@ func TestGetTimeZonesForPrefix(t *testing.T) {
 			t.Errorf("Expected at least 1 timezone.")
 		}
 
-		if timeZones[0] != test.expectedTimeZone {
-			t.Errorf("Expected '%s', got '%s' for '%s'", test.expectedTimeZone, timeZones[0], num)
+		if !reflect.DeepEqual(timeZones, test.expectedTimeZones) {
+			t.Errorf("Expected '%v', got '%v' for '%s'", test.expectedTimeZones, timeZones, num)
 		}
 	}
 }


### PR DESCRIPTION
When the length of the number supplied to GetTimezonesForPrefix was less than timezoneMap.MaxLength, the function call would result in a panic because of a slice index out of bounds.

This happened with +31112 for instance, which is a valid short number, and +6837000 which is a valid regular number (according to IsValidNumber).

This patch will make sure the matching length cannot be longer than the length of the given number.