### PR TITLE
Standardize country code letter case before parsing.

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -2799,6 +2799,7 @@ func checkRegionForParsing(numberToParse, defaultRegion string) bool {
 // done separately with IsValidNumber().
 func Parse(numberToParse, defaultRegion string) (*PhoneNumber, error) {
 	var phoneNumber *PhoneNumber = &PhoneNumber{}
+	defaultRegion = strings.ToUpper(defaultRegion)
 	err := ParseToNumber(numberToParse, defaultRegion, phoneNumber)
 	return phoneNumber, err
 }


### PR DESCRIPTION
converts the country code to upper case before parsing. 