### PR TITLE
Fix regex matching in GetLengthOfNationalDestinationCode

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -937,7 +937,7 @@ func GetLengthOfNationalDestinationCode(number *PhoneNumber) int {
 	}
 
 	nationalSignificantNumber := Format(copiedProto, INTERNATIONAL)
-	numberGroups := NON_DIGITS_PATTERN.FindAllString(nationalSignificantNumber, -1)
+	numberGroups := NON_DIGITS_PATTERN.Split(nationalSignificantNumber, -1)
 
 	// The pattern will start with "+COUNTRY_CODE " so the first group
 	// will always be the empty string (before the + symbol) and the
@@ -959,7 +959,7 @@ func GetLengthOfNationalDestinationCode(number *PhoneNumber) int {
 			return len(numberGroups[1]) + len(numberGroups[2])
 		}
 	}
-	return len(numberGroups[1])
+	return len(numberGroups[2])
 }
 
 // Returns the mobile token for the provided country calling code if it

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -937,7 +937,7 @@ func GetLengthOfNationalDestinationCode(number *PhoneNumber) int {
 	}
 
 	nationalSignificantNumber := Format(copiedProto, INTERNATIONAL)
-	numberGroups := DIGITS_PATTERN.FindAllString(nationalSignificantNumber, -1)
+	numberGroups := NON_DIGITS_PATTERN.FindAllString(nationalSignificantNumber, -1)
 
 	// The pattern will start with "+COUNTRY_CODE " so the first group
 	// will always be the empty string (before the + symbol) and the

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -822,13 +822,13 @@ func TestGetLengthOfGeographicalAreaCode(t *testing.T) {
 		numName string
 		length  int
 	}{
-		{numName: "US_NUMBER", length: 1},
+		{numName: "US_NUMBER", length: 3},
 		{numName: "US_TOLLFREE", length: 0},
-		{numName: "GB_NUMBER", length: 1},
+		{numName: "GB_NUMBER", length: 2},
 		{numName: "GB_MOBILE", length: 0},
-		{numName: "AR_NUMBER", length: 1},
+		{numName: "AR_NUMBER", length: 2},
 		{numName: "AU_NUMBER", length: 1},
-		{numName: "IT_NUMBER", length: 1},
+		{numName: "IT_NUMBER", length: 2},
 		{numName: "SG_NUMBER", length: 0},
 		{numName: "US_SHORT_BY_ONE_NUMBER", length: 0},
 		{numName: "INTERNATIONAL_TOLL_FREE", length: 0},

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -822,13 +822,13 @@ func TestGetLengthOfGeographicalAreaCode(t *testing.T) {
 		numName string
 		length  int
 	}{
-		{numName: "US_NUMBER", length: 3},
+		{numName: "US_NUMBER", length: 1},
 		{numName: "US_TOLLFREE", length: 0},
-		{numName: "GB_NUMBER", length: 2},
+		{numName: "GB_NUMBER", length: 1},
 		{numName: "GB_MOBILE", length: 0},
-		{numName: "AR_NUMBER", length: 2},
+		{numName: "AR_NUMBER", length: 1},
 		{numName: "AU_NUMBER", length: 1},
-		{numName: "IT_NUMBER", length: 2},
+		{numName: "IT_NUMBER", length: 1},
 		{numName: "SG_NUMBER", length: 0},
 		{numName: "US_SHORT_BY_ONE_NUMBER", length: 0},
 		{numName: "INTERNATIONAL_TOLL_FREE", length: 0},


### PR DESCRIPTION
Different to the regex in JAVA implementation.

Refer to issue https://github.com/nyaruka/phonenumbers/issues/147