### PR TITLE
feat: add GetNationalPrefix method

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -3486,3 +3486,12 @@ func GetGeocodingForNumber(number *PhoneNumber, lang string) (string, error) {
 	}
 	return display.Regions(langT).Name(reg), nil
 }
+
+// GetNationalPrefix return the region national prefix of the number
+func GetNationalPrefix(number *PhoneNumber) string {
+	metadata := getMetadataForRegion(GetRegionCodeForNumber(number))
+	if metadata == nil {
+		return ""
+	}
+	return metadata.GetNationalPrefix()
+}

--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -1679,6 +1679,27 @@ func TestGetSafeCarrierDisplayNameForNumber(t *testing.T) {
 	}
 }
 
+func TestGetNationalPrefix(t *testing.T) {
+	tests := []struct {
+		num      string
+		expected string
+	}{
+		{num: "+1213-290-1064", expected: "1"},
+		{num: "+8601087777777", expected: "0"},
+		{num: "+442079460958", expected: "0"},
+	}
+	for _, test := range tests {
+		number, err := Parse(test.num, "CN")
+		if err != nil {
+			t.Errorf("Failed to parse number %s: %s", test.num, err)
+		}
+		nationalPrefix := GetNationalPrefix(number)
+		if test.expected != nationalPrefix {
+			t.Errorf("Expected '%s', got '%s' for '%s'", test.expected, nationalPrefix, test.num)
+		}
+	}
+}
+
 func s(str string) *string {
 	return &str
 }


### PR DESCRIPTION
Now that we are able to obtain the area code, but there is no method available to retrieve the national prefix. When displaying the area code and number separately to users, we hope to add the national prefix to the area code to facilitate users in obtaining customary telephone information.