### PR TITLE
Implement PhoneNumberMatcher for regional contexts

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -42,7 +42,7 @@ func NewPhoneNumberMatcherForRegion(seq string, region string) *PhoneNumberMatch
 
 	// Append the length of the sequence as an end index if not already included.
 	if len(unwantedEndIndices) == 0 || unwantedEndIndices[len(unwantedEndIndices)-1] != len(seq) {
-		unwantedEndIndices = append(unwantedEndIndices, len(seq))
+		unwantedEndIndices = append(unwantedEndIndices, len(seq)-1)
 	}
 
 	// Iterate over each possible start index.
@@ -52,7 +52,7 @@ func NewPhoneNumberMatcherForRegion(seq string, region string) *PhoneNumberMatch
 				continue // Ensure the end index is after the start index.
 			}
 			// Explore the sequence between the start and end indices to find valid phone numbers.
-			for k := startIndices[i]; k < unwantedEndIndices[j]; k++ {
+			for k := startIndices[i]; k <= unwantedEndIndices[j]; k++ {
 				if k-startIndices[i] > MAX_LENGTH_COUNTRY_CODE+MAX_LENGTH_FOR_NSN {
 					break // Exceeds max phone number length, stop searching this slice.
 				}
@@ -60,7 +60,7 @@ func NewPhoneNumberMatcherForRegion(seq string, region string) *PhoneNumberMatch
 					continue // Does not meet min phone number length, continue searching.
 				}
 
-				phoneNumber, err := Parse(seq[startIndices[i]:k], region)
+				phoneNumber, err := Parse(seq[startIndices[i]:k+1], region)
 				if err != nil || !IsValidNumberForRegion(phoneNumber, region) {
 					continue // Skip invalid numbers or parse errors.
 				}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -29,6 +29,12 @@ func TestNewPhoneNumberMatcherForRegion(t *testing.T) {
 			region: "TN",
 			want:   map[uint64]int{71123456: 1, 71123457: 1},
 		},
+		{
+			name:   "Valid when sequence ends with a number",
+			seq:    "for more info 71123458",
+			region: "TN",
+			want:   map[uint64]int{71123458: 1},
+		},
 	}
 
 	for _, tt := range tests {

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,0 +1,50 @@
+package phonenumbers
+
+import (
+	"testing"
+)
+
+func TestNewPhoneNumberMatcherForRegion(t *testing.T) {
+	tests := []struct {
+		name   string
+		seq    string
+		region string
+		want   map[uint64]int // expected phone numbers with their expected counts
+	}{
+		{
+			name:   "Valid US numbers",
+			seq:    "Call me at 202-555-0130 or 415-555-0198 for more info.",
+			region: "US",
+			want:   map[uint64]int{2025550130: 1, 4155550198: 1},
+		},
+		{
+			name:   "Invalid patterns mixed with valid numbers",
+			seq:    "Try 12345 and then call 503-555-0110 or reach out at 999-000",
+			region: "US",
+			want:   map[uint64]int{5035550110: 1},
+		},
+		{
+			name:   "Valid Tunisian numbers",
+			seq:    "Call me at 71 123 456 or 71 123 457 for more info.",
+			region: "TN",
+			want:   map[uint64]int{71123456: 1, 71123457: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewPhoneNumberMatcherForRegion(tt.seq, tt.region)
+			got := make(map[uint64]int)
+			for matcher != nil {
+				got[*matcher.PhoneNumber.NationalNumber]++
+				matcher = matcher.Next
+			}
+
+			for num, count := range tt.want {
+				if got[num] != count {
+					t.Errorf("Test %s failed: expected %d occurrences of %d, got %d", tt.name, count, num, got[num])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implementation for `PhoneNumberMatcher` that supports regional phone number validations. The main functionality is encapsulated in the `NewPhoneNumberMatcherForRegion` function, which efficiently identifies and validates phone numbers within a given textual sequence based on specified regional criteria.

### Key Features:
- [x] Regional phone number parsing and validation.
- [ ] Phone number parsing and validation for unknown regions.

My implementation is a bit verbose and may make unnecessary extractions. Making it less verbose always led me to make some sacrifices. I left it to the user to define his own level of leniency instead.