### PR TITLE
Fix stale Ahmedabad geocoding test after upstream data update

### DIFF
--- a/phonenumbers_test.go
+++ b/phonenumbers_test.go
@@ -1427,7 +1427,7 @@ func TestGetGeocodingForNumber(t *testing.T) {
 		{num: "+8613702032331", lang: "zh", expected: "天津市"},
 		{num: "+863197785050", lang: "zh", expected: "河北省邢台市"},
 		{num: "+8613323241342", lang: "en", expected: "Baoding, Hebei"},
-		{num: "+917999999543", lang: "en", expected: "Ahmedabad Local, Gujarat"},
+		{num: "+917999499543", lang: "en", expected: "Ahmedabad Local, Gujarat"},
 		{num: "+17047181840", lang: "en", expected: "North Carolina"},
 		{num: "+12542462158", lang: "en", expected: "Texas"},
 		{num: "+16193165996", lang: "en", expected: "California"},


### PR DESCRIPTION
## Summary

Fixes the failing `TestGetGeocodingForNumber` test case on `main` (CI red since [12a1da9](https://github.com/nyaruka/phonenumbers/commit/12a1da9)).

The latest metadata refresh pulled new upstream libphonenumber data where the 5-digit `91799` Ahmedabad prefix has been split into specific 7-digit prefixes — present entries are `9179902`-`9179997` in a regular pattern (`x2-x7`, `x12-x17`, `x22-x27`, …), but `9179999` is not among them. As a result, `+917999999543` no longer matches any prefix and the lookup falls through to the country-name fallback (`"India"`).

Switched the test number to `+917999499543`, which matches the still-present `9179994 | Ahmedabad Local, Gujarat` prefix.

## Test plan

- [x] `go test -run TestGetGeocodingForNumber ./...` passes
- [x] Full `go test ./...` passes