### PR TITLE
Add metadata-injection seam for testing against alternate metadata

### DIFF
--- a/metadatasource.go
+++ b/metadatasource.go
@@ -5,17 +5,94 @@ package phonenumbers
 
 import "google.golang.org/protobuf/proto"
 
+// metadataContainer bundles all of the metadata-derived lookup state used by
+// the library. The package keeps a single active container (currentMetadata),
+// built from the embedded metadata during init. Bundling the state behind one
+// swappable value is the seam that lets tests run against alternate metadata
+// (e.g. upstream's synthetic PhoneNumberMetadataForTesting data) without
+// changing the public, package-level API.
+type metadataContainer struct {
+	// The parsed metadata collection this container was built from.
+	metadataCollection *PhoneMetadataCollection
+
+	// A map from country code (as integer) to two letter region codes.
+	countryCodeToRegion map[int][]string
+
+	// A mapping from a region code to the PhoneMetadata for that region.
+	regionToMetadataMap map[string]*PhoneMetadata
+
+	// A mapping from a country calling code for a non-geographical entity to
+	// the PhoneMetadata for that country calling code. Examples of the country
+	// calling codes include 800 (International Toll Free Service) and 808
+	// (International Shared Cost Service).
+	countryCodeToNonGeographicalMetadataMap map[int]*PhoneMetadata
+
+	// The set of regions that share country calling code 1.
+	nanpaRegions map[string]struct{}
+
+	// The set of regions the library supports.
+	supportedRegions map[string]bool
+
+	// All the calling codes we support.
+	supportedCallingCodes map[int]bool
+
+	// The set of calling codes that map to the non-geo entity region ("001").
+	countryCodesForNonGeographicalRegion map[int]bool
+}
+
+// currentMetadata is the active metadata container. It is populated from the
+// embedded metadata by initMetadata during package initialization. Tests may
+// swap it via useMetadata to exercise the library against alternate metadata.
+var currentMetadata *metadataContainer
+
 func initMetadata() {
 	// load our regions
 	regionMap, err := loadIntArrayMap(regionData)
 	if err != nil {
 		panic(err)
 	}
-	countryCodeToRegion = regionMap.Map
 
 	// then our metadata
-	if err = loadMetadataFromFile(); err != nil {
+	coll, err := MetadataCollection()
+	if err != nil {
 		panic(err)
+	}
+
+	currentMetadata, err = newMetadataContainer(coll, regionMap.Map)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// newMetadataContainer builds a fully populated metadataContainer from a parsed
+// metadata collection and a country-code-to-region map. This is the same
+// derivation the library has always performed at init, now factored out so it
+// can run against any metadata source, not just the embedded one.
+func newMetadataContainer(coll *PhoneMetadataCollection, countryCodeToRegion map[int][]string) (*metadataContainer, error) {
+	metadataList := coll.GetMetadata()
+	if len(metadataList) == 0 {
+		return nil, ErrEmptyMetadata
+	}
+
+	mc := &metadataContainer{
+		metadataCollection:                      coll,
+		countryCodeToRegion:                     countryCodeToRegion,
+		regionToMetadataMap:                     make(map[string]*PhoneMetadata),
+		countryCodeToNonGeographicalMetadataMap: make(map[int]*PhoneMetadata),
+		nanpaRegions:                            make(map[string]struct{}),
+		supportedRegions:                        make(map[string]bool, 320),
+		supportedCallingCodes:                   make(map[int]bool, 320),
+		countryCodesForNonGeographicalRegion:    make(map[int]bool, 16),
+	}
+
+	for _, meta := range metadataList {
+		region := meta.GetId()
+		if region == "001" {
+			// it's a non geographical entity
+			mc.countryCodeToNonGeographicalMetadataMap[int(meta.GetCountryCode())] = meta
+		} else {
+			mc.regionToMetadataMap[region] = meta
+		}
 	}
 
 	for eKey, regionCodes := range countryCodeToRegion {
@@ -25,114 +102,54 @@ func initMetadata() {
 		if len(regionCodes) == 1 && REGION_CODE_FOR_NON_GEO_ENTITY == regionCodes[0] {
 			// This is the subset of all country codes that map to the
 			// non-geo entity region code.
-			countryCodesForNonGeographicalRegion[eKey] = true
+			mc.countryCodesForNonGeographicalRegion[eKey] = true
 		} else {
 			// The supported regions set does not include the "001"
 			// non-geo entity region code.
 			for _, val := range regionCodes {
-				supportedRegions[val] = true
+				mc.supportedRegions[val] = true
 			}
 		}
 
-		supportedCallingCodes[eKey] = true
+		mc.supportedCallingCodes[eKey] = true
 	}
-	// If the non-geo entity still got added to the set of supported
-	// regions it must be because there are entries that list the non-geo
-	// entity alongside normal regions (which is wrong). If we discover
-	// this, remove the non-geo entity from the set of supported regions
-	// and log (or not log).
-	delete(supportedRegions, REGION_CODE_FOR_NON_GEO_ENTITY)
+	// If the non-geo entity still got added to the set of supported regions it
+	// must be because there are entries that list the non-geo entity alongside
+	// normal regions (which is wrong). If we discover this, remove the non-geo
+	// entity from the set of supported regions.
+	delete(mc.supportedRegions, REGION_CODE_FOR_NON_GEO_ENTITY)
 
 	for _, val := range countryCodeToRegion[NANPA_COUNTRY_CODE] {
-		writeToNanpaRegions(val, struct{}{})
+		mc.nanpaRegions[val] = struct{}{}
 	}
+
+	return mc, nil
 }
 
-var (
-	// The set of regions that share country calling code 1.
-	// There are roughly 26 regions.
-	nanpaRegions = make(map[string]struct{})
-
-	// A mapping from a region code to the PhoneMetadata for that region.
-	// Note: Synchronization, though only needed for the Android version
-	// of the library, is used in all versions for consistency.
-	regionToMetadataMap = make(map[string]*PhoneMetadata)
-
-	// A mapping from a country calling code for a non-geographical
-	// entity to the PhoneMetadata for that country calling code.
-	// Examples of the country calling codes include 800 (International
-	// Toll Free Service) and 808 (International Shared Cost Service).
-	// Note: Synchronization, though only needed for the Android version
-	// of the library, is used in all versions for consistency.
-	countryCodeToNonGeographicalMetadataMap = make(map[int]*PhoneMetadata)
-
-	// The set of regions the library supports.
-	// There are roughly 240 of them and we set the initial capacity of
-	// the HashSet to 320 to offer a load factor of roughly 0.75.
-	supportedRegions = make(map[string]bool, 320)
-
-	// The set of calling codes that map to the non-geo entity
-	// region ("001"). This set currently contains < 12 elements so the
-	// default capacity of 16 (load factor=0.75) is fine.
-	countryCodesForNonGeographicalRegion = make(map[int]bool, 16)
-
-	// All the calling codes we support
-	supportedCallingCodes = make(map[int]bool, 320)
-
-	// Our map from country code (as integer) to two letter region codes
-	countryCodeToRegion map[int][]string
-)
+// useMetadata swaps the active metadata container, returning a function that
+// restores the previously active container. It is intended for tests that need
+// to run against alternate (e.g. synthetic) metadata; callers must invoke the
+// returned restore function (typically via t.Cleanup) and must not run such
+// tests in parallel, since the active container is process-global.
+func useMetadata(mc *metadataContainer) (restore func()) {
+	prev := currentMetadata
+	currentMetadata = mc
+	return func() { currentMetadata = prev }
+}
 
 func readFromNanpaRegions(key string) (struct{}, bool) {
-	v, ok := nanpaRegions[key]
+	v, ok := currentMetadata.nanpaRegions[key]
 	return v, ok
-}
-
-func writeToNanpaRegions(key string, val struct{}) {
-	nanpaRegions[key] = val
 }
 
 func readFromRegionToMetadataMap(key string) (*PhoneMetadata, bool) {
-	v, ok := regionToMetadataMap[key]
+	v, ok := currentMetadata.regionToMetadataMap[key]
 	return v, ok
-}
-
-func writeToRegionToMetadataMap(key string, val *PhoneMetadata) {
-	regionToMetadataMap[key] = val
 }
 
 func readFromCountryCodeToNonGeographicalMetadataMap(key int) (*PhoneMetadata, bool) {
-	v, ok := countryCodeToNonGeographicalMetadataMap[key]
+	v, ok := currentMetadata.countryCodeToNonGeographicalMetadataMap[key]
 	return v, ok
-}
-
-func writeToCountryCodeToNonGeographicalMetadataMap(key int, v *PhoneMetadata) {
-	countryCodeToNonGeographicalMetadataMap[key] = v
-}
-
-func loadMetadataFromFile() error {
-	metadataCollection, err := MetadataCollection()
-	if err != nil {
-		return err
-	} else if currMetadataColl == nil {
-		currMetadataColl = metadataCollection
-	}
-
-	metadataList := metadataCollection.GetMetadata()
-	if len(metadataList) == 0 {
-		return ErrEmptyMetadata
-	}
-
-	for _, meta := range metadataList {
-		region := meta.GetId()
-		if region == "001" {
-			// it's a non geographical entity
-			writeToCountryCodeToNonGeographicalMetadataMap(int(meta.GetCountryCode()), meta)
-		} else {
-			writeToRegionToMetadataMap(region, meta)
-		}
-	}
-	return nil
 }
 
 var (
@@ -140,6 +157,9 @@ var (
 	reloadMetadata   = true
 )
 
+// MetadataCollection returns the embedded territory metadata collection. The
+// result is parsed once and cached; it always reflects the embedded data and
+// is independent of any container swapped in via useMetadata.
 func MetadataCollection() (*PhoneMetadataCollection, error) {
 	if !reloadMetadata {
 		return currMetadataColl, nil
@@ -150,8 +170,11 @@ func MetadataCollection() (*PhoneMetadataCollection, error) {
 		return nil, err
 	}
 
-	var metadataCollection = &PhoneMetadataCollection{}
-	err = proto.Unmarshal(rawBytes, metadataCollection)
+	metadataCollection := &PhoneMetadataCollection{}
+	if err = proto.Unmarshal(rawBytes, metadataCollection); err != nil {
+		return nil, err
+	}
+	currMetadataColl = metadataCollection
 	reloadMetadata = false
-	return metadataCollection, err
+	return metadataCollection, nil
 }

--- a/metadatasource_test.go
+++ b/metadatasource_test.go
@@ -1,0 +1,85 @@
+package phonenumbers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// syntheticCollection builds a tiny, frozen metadata collection for a single
+// made-up region so a test can exercise the library against data that never
+// changes. This is the Go analogue of upstream's PhoneNumberMetadataForTesting.
+func syntheticCollection() (*PhoneMetadataCollection, map[int][]string) {
+	sevenDigits := func() *PhoneNumberDesc {
+		return &PhoneNumberDesc{
+			NationalNumberPattern: proto.String(`\d{7}`),
+			PossibleLength:        []int32{7},
+		}
+	}
+	// "NA" never matches; the real builder always populates every type
+	// descriptor (empty where absent), and getNumberTypeHelper relies on that,
+	// so synthetic metadata must do the same.
+	na := func() *PhoneNumberDesc { return &PhoneNumberDesc{NationalNumberPattern: proto.String("NA")} }
+	coll := &PhoneMetadataCollection{
+		Metadata: []*PhoneMetadata{
+			{
+				Id:                  proto.String("XX"),
+				CountryCode:         proto.Int32(999),
+				InternationalPrefix: proto.String("00"),
+				GeneralDesc:         sevenDigits(),
+				FixedLine:           sevenDigits(),
+				Mobile:              na(),
+				PremiumRate:         na(),
+				TollFree:            na(),
+				SharedCost:          na(),
+				Voip:                na(),
+				PersonalNumber:      na(),
+				Pager:               na(),
+				Uan:                 na(),
+				Voicemail:           na(),
+			},
+		},
+	}
+	return coll, map[int][]string{999: {"XX"}}
+}
+
+// TestMetadataInjectionSeam proves that useMetadata swaps the data the public,
+// package-level API reads from, then cleanly restores the embedded metadata.
+// This is the seam that lets us adopt upstream's synthetic-metadata test suite
+// without coupling assertions to the real metadata (which changes every release).
+func TestMetadataInjectionSeam(t *testing.T) {
+	// Baseline: embedded real metadata is active.
+	require.NotNil(t, currentMetadata)
+	assert.Contains(t, GetSupportedRegions(), "US")
+	assert.Equal(t, 1, GetCountryCodeForRegion("US"))
+	assert.NotContains(t, GetSupportedRegions(), "XX")
+
+	// Swap in synthetic metadata for a made-up region.
+	coll, ccToRegion := syntheticCollection()
+	mc, err := newMetadataContainer(coll, ccToRegion)
+	require.NoError(t, err)
+	restore := useMetadata(mc)
+
+	// The public API now sees ONLY the synthetic region.
+	assert.Equal(t, map[string]bool{"XX": true}, GetSupportedRegions())
+	assert.Equal(t, 999, GetCountryCodeForRegion("XX"))
+	assert.Equal(t, 0, GetCountryCodeForRegion("US"))
+	assert.Equal(t, "XX", GetRegionCodeForCountryCode(999))
+
+	// And it validates/types numbers per the synthetic patterns.
+	num := &PhoneNumber{CountryCode: proto.Int32(999), NationalNumber: proto.Uint64(1234567)}
+	assert.Equal(t, FIXED_LINE, GetNumberType(num))
+	assert.True(t, IsValidNumberForRegion(num, "XX"))
+
+	// Restore and confirm the embedded metadata is back, unchanged.
+	restore()
+	assert.Contains(t, GetSupportedRegions(), "US")
+	assert.NotContains(t, GetSupportedRegions(), "XX")
+	assert.Equal(t, 1, GetCountryCodeForRegion("US"))
+
+	// newMetadataContainer rejects an empty collection.
+	_, err = newMetadataContainer(&PhoneMetadataCollection{}, nil)
+	assert.ErrorIs(t, err, ErrEmptyMetadata)
+}

--- a/metadatasource_test.go
+++ b/metadatasource_test.go
@@ -61,6 +61,10 @@ func TestMetadataInjectionSeam(t *testing.T) {
 	mc, err := newMetadataContainer(coll, ccToRegion)
 	require.NoError(t, err)
 	restore := useMetadata(mc)
+	// Guarantee restoration even if an assertion below panics, so the synthetic
+	// metadata can't leak into other tests in the package. restore is
+	// idempotent, so the explicit restore() check further down stays valid.
+	t.Cleanup(restore)
 
 	// The public API now sees ONLY the synthetic region.
 	assert.Equal(t, map[string]bool{"XX": true}, GetSupportedRegions())

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -807,7 +807,7 @@ func normalizeHelper(number string,
 
 // GetSupportedRegions returns all regions the library has metadata for.
 func GetSupportedRegions() map[string]bool {
-	return supportedRegions
+	return currentMetadata.supportedRegions
 }
 
 // GetSupportedCallingCodes returns all country calling codes the library has metadata for, covering both non-geographical
@@ -815,12 +815,12 @@ func GetSupportedRegions() map[string]bool {
 // used to populate a drop-down box of country calling codes for a phone-number widget, for
 // instance.
 func GetSupportedCallingCodes() map[int]bool {
-	return supportedCallingCodes
+	return currentMetadata.supportedCallingCodes
 }
 
 // GetSupportedGlobalNetworkCallingCodes returns all global network calling codes the library has metadata for.
 func GetSupportedGlobalNetworkCallingCodes() map[int]bool {
-	return countryCodesForNonGeographicalRegion
+	return currentMetadata.countryCodesForNonGeographicalRegion
 }
 
 // Helper function to check if the national prefix formatting rule has the
@@ -848,13 +848,13 @@ func isNumberGeographical(phoneNumber *PhoneNumber) bool {
 
 // Helper function to check region code is not unknown or null.
 func isValidRegionCode(regionCode string) bool {
-	valid := supportedRegions[regionCode]
+	valid := currentMetadata.supportedRegions[regionCode]
 	return len(regionCode) != 0 && valid
 }
 
 // Helper function to check the country calling code is valid.
 func hasValidCountryCallingCode(countryCallingCode int) bool {
-	_, containsKey := countryCodeToRegion[countryCallingCode]
+	_, containsKey := currentMetadata.countryCodeToRegion[countryCallingCode]
 	return containsKey
 }
 
@@ -1864,7 +1864,7 @@ func getMetadataForRegion(regionCode string) *PhoneMetadata {
 }
 
 func getMetadataForNonGeographicalRegion(countryCallingCode int) *PhoneMetadata {
-	_, ok := countryCodeToRegion[countryCallingCode]
+	_, ok := currentMetadata.countryCodeToRegion[countryCallingCode]
 	if !ok {
 		return nil
 	}
@@ -1938,7 +1938,7 @@ func IsValidNumberForRegion(number *PhoneNumber, regionCode string) bool {
 // geocoding at the region level.
 func GetRegionCodeForNumber(number *PhoneNumber) string {
 	var countryCode int = int(number.GetCountryCode())
-	var regions []string = countryCodeToRegion[countryCode]
+	var regions []string = currentMetadata.countryCodeToRegion[countryCode]
 	if len(regions) == 0 {
 		return ""
 	}
@@ -1980,7 +1980,7 @@ func getRegionCodeForNumberFromRegionList(
 // value "001" will be returned (corresponding to the value for World in
 // the UN M.49 schema).
 func GetRegionCodeForCountryCode(countryCallingCode int) string {
-	var regionCodes []string = countryCodeToRegion[countryCallingCode]
+	var regionCodes []string = currentMetadata.countryCodeToRegion[countryCallingCode]
 	if len(regionCodes) == 0 {
 		return UNKNOWN_REGION
 	}
@@ -1992,7 +1992,7 @@ func GetRegionCodeForCountryCode(countryCallingCode int) string {
 // code 001 is returned. Also, in the case of no region code being found,
 // an empty list is returned.
 func GetRegionCodesForCountryCode(countryCallingCode int) []string {
-	var regionCodes []string = countryCodeToRegion[countryCallingCode]
+	var regionCodes []string = currentMetadata.countryCodeToRegion[countryCallingCode]
 	return regionCodes
 }
 
@@ -2279,7 +2279,7 @@ func extractCountryCode(fullNumber, nationalNumber *Builder) int {
 	)
 	for i := 1; i <= MAX_LENGTH_COUNTRY_CODE && i <= numberLength; i++ {
 		potentialCountryCode, _ = strconv.Atoi(string(fullNumBytes[0:i]))
-		if _, ok := countryCodeToRegion[potentialCountryCode]; ok {
+		if _, ok := currentMetadata.countryCodeToRegion[potentialCountryCode]; ok {
 			nationalNumber.Write(fullNumBytes[i:])
 			return potentialCountryCode
 		}


### PR DESCRIPTION
## What

Introduces a seam that lets the library run against alternate, frozen metadata instead of the embedded metadata that changes every release. This is the keystone for adopting upstream's synthetic-metadata test suite (`PhoneNumberMetadataForTesting`), which is the fix for the recurring "stale test" breakages that happen whenever upstream refreshes real-world data.

Follows the file split in #229 and the plan in `docs/2.0-restructure.md` (§3.2 / §5).

## How

- Bundle the metadata-derived lookup state (region→metadata maps, supported-region / calling-code sets, NANPA regions, country-code→region map) into an internal `metadataContainer`, held in a single active package var `currentMetadata`, built from the embedded metadata during `init`.
- The package-level accessors and the ~10 direct reads now go through that container.
- `useMetadata(mc)` swaps the active container and returns a `restore` func for test setup/teardown.
- `newMetadataContainer(coll, ccToRegion)` factors out the derivation the library always did at init, so it can run against any parsed collection.

## No public API or behavior change

`Parse`, `Format`, `GetSupportedRegions`, etc. keep their exact signatures and, with the embedded metadata active, behave identically. Verified with the existing suite plus `-race`.

## Test

`TestMetadataInjectionSeam` builds a tiny synthetic single-region collection, swaps it in, and asserts the public API (`GetSupportedRegions`, `GetCountryCodeForRegion`, `GetRegionCodeForCountryCode`, `GetNumberType`, `IsValidNumberForRegion`) reads from it, then restores the embedded metadata and confirms it's unchanged. Building that fixture surfaced a useful invariant, now documented in the test: the type descriptors (`PremiumRate`, `TollFree`, …) must always be non-nil, since `getNumberTypeHelper` dereferences them — the real builder guarantees this, so synthetic metadata must too.

## Next steps (separate PRs)

- Extend `cmd/buildmetadata` to also compile `PhoneNumberMetadataForTesting.xml` into a committed test blob.
- Port `PhoneNumberUtilTest` / `ShortNumberInfoTest` against the synthetic metadata via this seam — making them stable across upstream data refreshes.