### PR TITLE
Fix national-prefix / $FG formatting-rule application

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -964,13 +964,18 @@ func FormatByPattern(number *PhoneNumber,
 			nationalPrefix := metadata.GetNationalPrefix()
 			if len(nationalPrefix) > 0 {
 				// Replace $NP with national prefix and $FG with the
-				// first group ($1).
+				// first group ($1). Java does rule.replace(FG_STRING, "$1"),
+				// inserting the literal characters "$1" so the first group is
+				// substituted later by formatNsnUsingPattern. Use a literal
+				// replacement here because Go's ReplaceAllString would treat
+				// "$1" as a group reference into FG_PATTERN (which has no
+				// groups), leaving a stray backslash instead.
 				nationalPrefixFormattingRule =
 					NP_PATTERN.ReplaceAllString(
 						nationalPrefixFormattingRule, nationalPrefix)
 				nationalPrefixFormattingRule =
-					FG_PATTERN.ReplaceAllString(
-						nationalPrefixFormattingRule, "\\$1")
+					FG_PATTERN.ReplaceAllLiteralString(
+						nationalPrefixFormattingRule, "$1")
 				numFormatCopy.NationalPrefixFormattingRule =
 					&nationalPrefixFormattingRule
 			} else {
@@ -1641,33 +1646,36 @@ func formatNsnUsingPatternWithCarrier(
 					return s
 				})
 		// Now replace the $FG in the formatting rule with the first group
-		// and the carrier code combined in the appropriate way.
-		i = 1
-		numberFormatRule = FIRST_GROUP_PATTERN.ReplaceAllStringFunc(
-			numberFormatRule,
-			func(s string) string {
-				if i > 0 {
-					i -= 1
-					return carrierCodeFormattingRule
-				}
-				return s
-			})
-		formattedNationalNumber = m.ReplaceAllString(nationalNumber, numberFormatRule)
+		// and the carrier code combined in the appropriate way. Mirror Java's
+		// firstGroupMatcher.replaceFirst(rule): replace only the first $-token,
+		// expanding "$1" in the rule to that matched token (FIRST_GROUP_PATTERN's
+		// group 1) rather than inserting the rule literally. So for a format whose
+		// first token is "$2" and a carrier rule of "$CC $1", the "$1" expands to
+		// "$2" rather than being left literal (which would emit the wrong group).
+		fgp := numberFormatRule
+		if loc := FIRST_GROUP_PATTERN.FindStringSubmatchIndex(numberFormatRule); loc != nil {
+			expanded := FIRST_GROUP_PATTERN.ExpandString(
+				nil, carrierCodeFormattingRule, numberFormatRule, loc)
+			fgp = numberFormatRule[:loc[0]] + string(expanded) + numberFormatRule[loc[1]:]
+		}
+		formattedNationalNumber = m.ReplaceAllString(nationalNumber, fgp)
 	} else {
 		// Use the national prefix formatting rule instead.
 		nationalPrefixFormattingRule :=
 			formattingPattern.GetNationalPrefixFormattingRule()
 		if numberFormat == NATIONAL &&
 			len(nationalPrefixFormattingRule) > 0 {
-			i := 1
-			fgp := FIRST_GROUP_PATTERN.ReplaceAllStringFunc(numberFormatRule,
-				func(s string) string {
-					if i > 0 {
-						i -= 1
-						return nationalPrefixFormattingRule
-					}
-					return s
-				})
+			// Mirror Java's firstGroupMatcher.replaceFirst(rule): replace only
+			// the first $-token, expanding "$1" in the rule to that matched
+			// token (FIRST_GROUP_PATTERN's group 1) rather than inserting the
+			// rule literally. So a rule of "$1" leaves the matched token
+			// unchanged, while "0$1" prefixes it with "0".
+			fgp := numberFormatRule
+			if loc := FIRST_GROUP_PATTERN.FindStringSubmatchIndex(numberFormatRule); loc != nil {
+				expanded := FIRST_GROUP_PATTERN.ExpandString(
+					nil, nationalPrefixFormattingRule, numberFormatRule, loc)
+				fgp = numberFormatRule[:loc[0]] + string(expanded) + numberFormatRule[loc[1]:]
+			}
 			formattedNationalNumber = m.ReplaceAllString(nationalNumber, fgp)
 		} else {
 			formattedNationalNumber = m.ReplaceAllString(

--- a/phonenumberutil_format_natprefix_test.go
+++ b/phonenumberutil_format_natprefix_test.go
@@ -1,0 +1,87 @@
+package phonenumbers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+// Regression tests for the national-prefix / $FG formatting-rule fix in
+// phonenumberutil.go. These cover the three places where a formatting rule's
+// first-group token must be applied the way upstream libphonenumber does
+// (Java's String.replace / Matcher.replaceFirst semantics):
+//
+//  1. FormatByPattern compiling a user-supplied $NP$FG rule,
+//  2. formatNsnUsingPattern applying a metadata national-prefix rule, and
+//  3. the carrier-code branch of formatNsnUsingPatternWithCarrier.
+//
+// The test-metadata cases run against the synthetic metadata so they never go
+// stale; TestFormatByPatternFGProdMetadata reproduces the original bug against
+// the real embedded metadata.
+
+func TestFormatNationalPrefixFormattingRule(t *testing.T) {
+	useTestMetadata(t)
+
+	// AR/MX mobile formats whose first $-token is "$2", with national-prefix
+	// rules "0$1"/"$1": the "$1" must expand to the matched token rather than
+	// being substituted literally (which would emit format group 1's digit).
+	assert.Equal(t, "011 15 8765-4321", Format(arMobile(), NATIONAL))
+	assert.Equal(t, "045 234 567 8900", Format(mxMobile1(), NATIONAL))
+	assert.Equal(t, "045 55 1234 5678", Format(mxMobile2(), NATIONAL))
+
+	// User-supplied rules containing $FG, compiled by FormatByPattern. $NP is
+	// "1" for NANPA regions and "0" for GB.
+	bs := &NumberFormat{
+		Pattern:                      proto.String(`(\d{3})(\d{3})(\d{4})`),
+		Format:                       proto.String("$1 $2-$3"),
+		NationalPrefixFormattingRule: proto.String("$NP ($FG)"),
+	}
+	assert.Equal(t, "1 (242) 365-1234", FormatByPattern(bsNumber(), NATIONAL, []*NumberFormat{bs}))
+
+	gbRule := func(rule string) []*NumberFormat {
+		return []*NumberFormat{{
+			Pattern:                      proto.String(`(\d{2})(\d{4})(\d{4})`),
+			Format:                       proto.String("$1 $2 $3"),
+			NationalPrefixFormattingRule: proto.String(rule),
+		}}
+	}
+	assert.Equal(t, "020 7031 3000", FormatByPattern(gbNumber(), NATIONAL, gbRule("$NP$FG")))
+	assert.Equal(t, "(020) 7031 3000", FormatByPattern(gbNumber(), NATIONAL, gbRule("($NP$FG)")))
+}
+
+// TestFormatByPatternFGProdMetadata is the original bug repro against the real
+// embedded metadata: a $NP$FG rule used to emit a literal backslash
+// ("0\ 7031 3000") because Go's regexp replacer treated "$1" as a group
+// reference into the groupless $FG pattern.
+func TestFormatByPatternFGProdMetadata(t *testing.T) {
+	num, err := Parse("+442070313000", "GB")
+	assert.NoError(t, err)
+
+	formats := []*NumberFormat{{
+		Pattern:                      proto.String(`(\d{2})(\d{4})(\d{4})`),
+		Format:                       proto.String("$1 $2 $3"),
+		NationalPrefixFormattingRule: proto.String("$NP$FG"),
+	}}
+	assert.Equal(t, "020 7031 3000", FormatByPattern(num, NATIONAL, formats))
+}
+
+// TestFormatWithCarrierCodeTestMetadata mirrors upstream PhoneNumberUtilTest.
+// testFormatWithCarrierCode against the synthetic test metadata. AR mobile
+// numbers exercise a carrier format whose first $-token is "$2" and whose
+// domesticCarrierCodeFormattingRule is "$NP$FG $CC" -> "0$1 $CC"; the "$1" must
+// expand to the matched first token ("$2"), not be left literal (which would
+// resolve to format group 1 and emit the wrong digit). This guards the
+// carrier-code branch of formatNsnUsingPatternWithCarrier.
+func TestFormatWithCarrierCodeTestMetadata(t *testing.T) {
+	useTestMetadata(t)
+
+	arMobile := newPhoneNumber(54, 92234654321)
+	assert.Equal(t, "02234 65-4321", Format(arMobile, NATIONAL))
+	// Here we force 14 as the carrier code.
+	assert.Equal(t, "02234 14 65-4321", FormatNationalNumberWithCarrierCode(arMobile, "14"))
+	// Here we force the number to be shown with no carrier code.
+	assert.Equal(t, "02234 65-4321", FormatNationalNumberWithCarrierCode(arMobile, ""))
+	// E164 ignores national/carrier formatting, so no carrier code is present.
+	assert.Equal(t, "+5492234654321", Format(arMobile, E164))
+}


### PR DESCRIPTION
## What

Fixes how a number-formatting rule's first-group token (`$FG` / `$1`) is applied, which was diverging from upstream libphonenumber in three places in `phonenumberutil.go`:

1. **`FormatByPattern` (`$FG` compilation)** — `$FG` was expanded with `regexp.ReplaceAllString(rule, "\$1")`, but Go's replacer treats `$1` as a group reference into `FG_PATTERN` (which has no capture groups), so it expanded to nothing and left a stray backslash. Switched to `ReplaceAllLiteralString(rule, "$1")`, inserting the literal `$1` — matching Java's `rule.replace(FG_STRING, "$1")`.
2. **`formatNsnUsingPattern` (national-prefix branch)** — the rule was substituted literally for the first `$`-token. Java's `Matcher.replaceFirst` treats `$1` in the rule as a backreference to the matched token, so `"$1"` leaves the token unchanged and `"0$1"` prefixes it. Replicated with `FindStringSubmatchIndex` + `ExpandString`.
3. **carrier-code branch of `formatNsnUsingPatternWithCarrier`** — had the same literal-substitution defect; applied the same fix.

## Why

A user-supplied `NationalPrefixFormattingRule` of `"$NP$FG"` produced a literal backslash instead of the first group. Repro against real metadata:

```go
FormatByPattern(parse("+442070313000","GB"), NATIONAL, []*NumberFormat{{
    Pattern: `(\d{2})(\d{4})(\d{4})`, Format: "$1 $2 $3", NationalPrefixFormattingRule: "$NP$FG",
}})
// before: "0\ 7031 3000"
// after:  "020 7031 3000"
```

The same root cause also produced wrong national/carrier formatting for regions whose format's first token isn't `$1` (e.g. AR/MX mobile, where the rule is `"$1"` or `"0$1"`).

## Tests

Adds `phonenumberutil_format_natprefix_test.go` with regression coverage against both the synthetic test metadata (GB `$NP$FG`/`($NP$FG)`, BS, AR/MX mobile NATIONAL, AR carrier-code) and the real embedded metadata (the GB repro above).

`gofmt`, `go vet`, and `go test ./...` all clean.