### PR TITLE
Port PhoneNumberUtilTest formatting tests (wave 3)

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -263,7 +263,11 @@ var (
 	// region, they will be represented as a regex string that always
 	// contains character(s) other than ASCII digits.
 	// Note this regex also includes tilde, which signals waiting for the tone.
-	UNIQUE_INTERNATIONAL_PREFIX = regexp.MustCompile("[\\d]+(?:[~\u2053\u223C\uFF5E][\\d]+)?")
+	// Anchored to require a full match, mirroring Java's Pattern.matches(): Go's
+	// MatchString is a partial (unanchored) match, which would wrongly treat a
+	// regex IDD prefix like "0[0-3][0-9]" as a unique prefix (matching its leading
+	// "0") instead of falling back to international "+" formatting.
+	UNIQUE_INTERNATIONAL_PREFIX = regexp.MustCompile("^(?:[\\d]+(?:[~\u2053\u223C\uFF5E][\\d]+)?)$")
 
 	PLUS_CHARS_PATTERN      = regexp.MustCompile("[" + PLUS_CHARS + "]+")
 	SEPARATOR_PATTERN       = regexp.MustCompile("[" + VALID_PUNCTUATION + "]+")

--- a/phonenumberutil_adhoc_test.go
+++ b/phonenumberutil_adhoc_test.go
@@ -250,52 +250,6 @@ func TestFormatInOriginalFormat(t *testing.T) {
 	}
 }
 
-func TestFormatOutOfCountryCallingNumber(t *testing.T) {
-	var tests = []struct {
-		in     string
-		exp    string
-		region string
-		frmt   PhoneNumberFormat
-	}{
-		{
-			in:     "+16505551234",
-			region: "US",
-			exp:    "1 (650) 555-1234",
-		}, {
-			in:     "+16505551234",
-			region: "CA",
-			exp:    "1 (650) 555-1234",
-		}, {
-			in:     "+16505551234",
-			region: "CH",
-			exp:    "00 1 650-555-1234",
-		}, {
-			in:     "+16505551234",
-			region: "ZZ",
-			exp:    "+1 650-555-1234",
-		}, {
-			in:     "+4911234",
-			region: "US",
-			exp:    "011 49 11234",
-		}, {
-			in:     "+4911234",
-			region: "DE",
-			exp:    "11234",
-		},
-	}
-
-	for i, test := range tests {
-		num, err := Parse(test.in, test.region)
-		if err != nil {
-			t.Errorf("[test %d] failed: should be able to parse, err:%v\n", i, err)
-		}
-		got := FormatOutOfCountryCallingNumber(num, test.region)
-		if got != test.exp {
-			t.Errorf("[test %d:fmt] failed %s != %s\n", i, got, test.exp)
-		}
-	}
-}
-
 func TestFormatOutOfCountryKeepingAlphaChars(t *testing.T) {
 	var tests = []struct {
 		in     string
@@ -1476,35 +1430,6 @@ func TestFormatWithCarrierCode(t *testing.T) {
 
 	// Invalid country code should just get the NSN
 	assert.Equal(t, "12345", FormatNationalNumberWithCarrierCode(getTestNumber("UNKNOWN_COUNTRY_CODE_NO_RAW_INPUT"), "89"))
-}
-
-func TestFormatWithPreferredCarrierCode(t *testing.T) {
-	// Test preferred carrier code using BR (Brazil) which uses carrier codes in production metadata
-	brNumber := newPhoneNumber(55, 1155256325)
-
-	// No preferred carrier code set - use fallback
-	assert.Equal(t, "0 15 (11) 5525-6325", FormatNationalNumberWithPreferredCarrierCode(brNumber, "15"))
-	assert.Equal(t, "(11) 5525-6325", FormatNationalNumberWithPreferredCarrierCode(brNumber, ""))
-
-	// Preferred carrier code set
-	brNumber.PreferredDomesticCarrierCode = proto.String("19")
-	assert.Equal(t, "(11) 5525-6325", Format(brNumber, NATIONAL))
-	assert.Equal(t, "0 19 (11) 5525-6325", FormatNationalNumberWithPreferredCarrierCode(brNumber, "15"))
-	assert.Equal(t, "0 19 (11) 5525-6325", FormatNationalNumberWithPreferredCarrierCode(brNumber, ""))
-
-	// When preferred_domestic_carrier_code is a space, use it
-	brNumber.PreferredDomesticCarrierCode = proto.String(" ")
-	assert.Equal(t, "0   (11) 5525-6325", FormatNationalNumberWithPreferredCarrierCode(brNumber, "15"))
-
-	// When preferred_domestic_carrier_code is empty, use fallback
-	brNumber.PreferredDomesticCarrierCode = proto.String("")
-	assert.Equal(t, "0 15 (11) 5525-6325", FormatNationalNumberWithPreferredCarrierCode(brNumber, "15"))
-
-	// US doesn't use carrier codes so there should be no change
-	usNumber := newPhoneNumber(1, 4241231234)
-	usNumber.PreferredDomesticCarrierCode = proto.String("99")
-	assert.Equal(t, "(424) 123-1234", Format(usNumber, NATIONAL))
-	assert.Equal(t, "(424) 123-1234", FormatNationalNumberWithPreferredCarrierCode(usNumber, "15"))
 }
 
 func TestFormatOutOfCountryKeepingAlphaCharsWithExtension(t *testing.T) {

--- a/phonenumberutil_adhoc_test.go
+++ b/phonenumberutil_adhoc_test.go
@@ -174,33 +174,6 @@ func TestTruncateTooLongNumber(t *testing.T) {
 	}
 }
 
-func TestFormat(t *testing.T) {
-	// useful link for validating against official lib:
-	// http://libphonenumber.appspot.com/phonenumberparser?number=019+3286+9755&country=GB
-
-	var tests = []struct {
-		input    string
-		region   string
-		frmt     PhoneNumberFormat
-		expected string
-	}{
-		{input: "019 3286 9755", region: "GB", frmt: NATIONAL, expected: "01932 869755"},
-		{input: "+44 (0) 1932 869755", region: "GB", frmt: INTERNATIONAL, expected: "+44 1932 869755"},
-		{input: "4431234567", region: "US", frmt: NATIONAL, expected: "(443) 123-4567"},
-		{input: "4431234567", region: "US", frmt: E164, expected: "+14431234567"},
-		{input: "4431234567", region: "US", frmt: INTERNATIONAL, expected: "+1 443-123-4567"},
-		{input: "4431234567", region: "US", frmt: RFC3966, expected: "tel:+1-443-123-4567"},
-		{input: "+1 100-083-0033", region: "US", frmt: INTERNATIONAL, expected: "+1 1000830033"},
-	}
-
-	for _, tc := range tests {
-		num, err := Parse(tc.input, tc.region)
-		assert.NoError(t, err, "unexpected error for input %s", tc.input)
-
-		assert.Equal(t, tc.expected, Format(num, tc.frmt), "formatted mismatch for input=%s fmt=%d", tc.input, tc.frmt)
-	}
-}
-
 func TestFormatForMobileDialing(t *testing.T) {
 	var tests = []struct {
 		in     string
@@ -223,51 +196,6 @@ func TestFormatForMobileDialing(t *testing.T) {
 		got := FormatNumberForMobileDialing(num, test.region, false)
 		if got != test.exp {
 			t.Errorf("[test %d:fmt] failed %s != %s\n", i, got, test.exp)
-		}
-	}
-}
-
-func TestFormatByPattern(t *testing.T) {
-	var tcs = []struct {
-		in          string
-		region      string
-		format      PhoneNumberFormat
-		userFormats []*NumberFormat
-		exp         string
-	}{
-		{
-			in:     "+33122334455",
-			region: "FR",
-			format: E164,
-			userFormats: []*NumberFormat{
-				{
-					Pattern: s(`(\d+)`),
-					Format:  s(`$1`),
-				},
-			},
-			exp: "+33122334455",
-		}, {
-			in:     "+442070313000",
-			region: "UK",
-			format: NATIONAL,
-			userFormats: []*NumberFormat{
-				{
-					Pattern: s(`(20)(\d{4})(\d{4})`),
-					Format:  s(`$1 $2 $3`),
-				},
-			},
-			exp: "20 7031 3000",
-		},
-	}
-
-	for i, tc := range tcs {
-		num, err := Parse(tc.in, tc.region)
-		if err != nil {
-			t.Errorf("[test %d] failed: should be able to parse, err:%v\n", i, err)
-		}
-		got := FormatByPattern(num, tc.format, tc.userFormats)
-		if got != tc.exp {
-			t.Errorf("[test %d:fmt] failed %s != %s\n", i, got, tc.exp)
 		}
 	}
 }

--- a/phonenumberutil_format_outofcountry_test.go
+++ b/phonenumberutil_format_outofcountry_test.go
@@ -1,0 +1,88 @@
+package phonenumbers
+
+// Faithful port of upstream libphonenumber's PhoneNumberUtilTest.java
+// out-of-country / preferred-carrier formatting tests, run against the synthetic
+// test metadata. Method names and assertions mirror the Java. Last reconciled
+// against: v9.0.32
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFormatOutOfCountryCallingNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "00 1 900 253 0000", FormatOutOfCountryCallingNumber(usPremium(), regionCode.DE))
+	assert.Equal(t, "1 650 253 0000", FormatOutOfCountryCallingNumber(usNumber(), regionCode.BS))
+	assert.Equal(t, "00 1 650 253 0000", FormatOutOfCountryCallingNumber(usNumber(), regionCode.PL))
+	assert.Equal(t, "011 44 7912 345 678", FormatOutOfCountryCallingNumber(gbMobile(), regionCode.US))
+	assert.Equal(t, "00 49 1234", FormatOutOfCountryCallingNumber(deShortNumber(), regionCode.GB))
+	// Note this number is correctly formatted without national prefix.
+	assert.Equal(t, "1234", FormatOutOfCountryCallingNumber(deShortNumber(), regionCode.DE))
+
+	assert.Equal(t, "011 39 02 3661 8300", FormatOutOfCountryCallingNumber(itNumber(), regionCode.US))
+	assert.Equal(t, "02 3661 8300", FormatOutOfCountryCallingNumber(itNumber(), regionCode.IT))
+	assert.Equal(t, "+39 02 3661 8300", FormatOutOfCountryCallingNumber(itNumber(), regionCode.SG))
+
+	assert.Equal(t, "6521 8000", FormatOutOfCountryCallingNumber(sgNumber(), regionCode.SG))
+
+	assert.Equal(t, "011 54 9 11 8765 4321", FormatOutOfCountryCallingNumber(arMobile(), regionCode.US))
+	assert.Equal(t, "011 800 1234 5678", FormatOutOfCountryCallingNumber(internationalTollFree(), regionCode.US))
+
+	arNumberWithExtn := arMobile()
+	arNumberWithExtn.Extension = proto.String("1234")
+	assert.Equal(t, "011 54 9 11 8765 4321 ext. 1234", FormatOutOfCountryCallingNumber(arNumberWithExtn, regionCode.US))
+	assert.Equal(t, "0011 54 9 11 8765 4321 ext. 1234", FormatOutOfCountryCallingNumber(arNumberWithExtn, regionCode.AU))
+	assert.Equal(t, "011 15 8765-4321 ext. 1234", FormatOutOfCountryCallingNumber(arNumberWithExtn, regionCode.AR))
+}
+
+func TestFormatOutOfCountryWithInvalidRegion(t *testing.T) {
+	useTestMetadata(t)
+
+	// AQ/Antarctica isn't a valid region code for phone number formatting, so this falls back to
+	// intl formatting.
+	assert.Equal(t, "+1 650 253 0000", FormatOutOfCountryCallingNumber(usNumber(), "AQ"))
+	// For region code 001, the out-of-country format always turns into the international format.
+	assert.Equal(t, "+1 650 253 0000", FormatOutOfCountryCallingNumber(usNumber(), regionCode.UN001))
+}
+
+func TestFormatOutOfCountryWithPreferredIntlPrefix(t *testing.T) {
+	useTestMetadata(t)
+
+	// This should use 0011, since that is the preferred international prefix (both 0011 and 0012
+	// are accepted as possible international prefixes in our test metadata.)
+	assert.Equal(t, "0011 39 02 3661 8300", FormatOutOfCountryCallingNumber(itNumber(), regionCode.AU))
+	// Testing preferred international prefixes with ~ are supported (designates waiting).
+	assert.Equal(t, "8~10 39 02 3661 8300", FormatOutOfCountryCallingNumber(itNumber(), regionCode.UZ))
+}
+
+func TestFormatWithPreferredCarrierCode(t *testing.T) {
+	useTestMetadata(t)
+
+	// We only support this for AR in our test metadata.
+	arNumber := pn(54, 91234125678)
+	// Test formatting with no preferred carrier code stored in the number itself.
+	assert.Equal(t, "01234 15 12-5678", FormatNationalNumberWithPreferredCarrierCode(arNumber, "15"))
+	assert.Equal(t, "01234 12-5678", FormatNationalNumberWithPreferredCarrierCode(arNumber, ""))
+	// Test formatting with preferred carrier code present.
+	arNumber.PreferredDomesticCarrierCode = proto.String("19")
+	assert.Equal(t, "01234 12-5678", Format(arNumber, NATIONAL))
+	assert.Equal(t, "01234 19 12-5678", FormatNationalNumberWithPreferredCarrierCode(arNumber, "15"))
+	assert.Equal(t, "01234 19 12-5678", FormatNationalNumberWithPreferredCarrierCode(arNumber, ""))
+	// When the preferred_domestic_carrier_code is present (even when it is just a space), use it
+	// instead of the default carrier code passed in.
+	arNumber.PreferredDomesticCarrierCode = proto.String(" ")
+	assert.Equal(t, "01234   12-5678", FormatNationalNumberWithPreferredCarrierCode(arNumber, "15"))
+	// When the preferred_domestic_carrier_code is present but empty, treat it as unset and use
+	// instead the default carrier code passed in.
+	arNumber.PreferredDomesticCarrierCode = proto.String("")
+	assert.Equal(t, "01234 15 12-5678", FormatNationalNumberWithPreferredCarrierCode(arNumber, "15"))
+	// We don't support this for the US so there should be no change.
+	usNumber := pn(1, 4241231234)
+	usNumber.PreferredDomesticCarrierCode = proto.String("99")
+	assert.Equal(t, "424 123 1234", Format(usNumber, NATIONAL))
+	assert.Equal(t, "424 123 1234", FormatNationalNumberWithPreferredCarrierCode(usNumber, "15"))
+}

--- a/phonenumberutil_format_test.go
+++ b/phonenumberutil_format_test.go
@@ -1,0 +1,237 @@
+package phonenumbers
+
+// Faithful port of upstream libphonenumber's PhoneNumberUtilTest.java formatting
+// tests, run against the synthetic test metadata (see testmetadata_test.go).
+// Method names and assertions mirror the Java so this file can be kept in sync
+// with upstream. Last reconciled against: v9.0.32
+//
+// Note: testFormatWithCarrierCode is already covered by
+// TestFormatWithCarrierCodeTestMetadata in phonenumberutil_format_natprefix_test.go;
+// the out-of-country / preferred-carrier / mobile-dialing / in-original-format
+// methods are ported separately.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFormatUSNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "650 253 0000", Format(usNumber(), NATIONAL))
+	assert.Equal(t, "+1 650 253 0000", Format(usNumber(), INTERNATIONAL))
+
+	assert.Equal(t, "800 253 0000", Format(usTollFree(), NATIONAL))
+	assert.Equal(t, "+1 800 253 0000", Format(usTollFree(), INTERNATIONAL))
+
+	assert.Equal(t, "900 253 0000", Format(usPremium(), NATIONAL))
+	assert.Equal(t, "+1 900 253 0000", Format(usPremium(), INTERNATIONAL))
+	assert.Equal(t, "tel:+1-900-253-0000", Format(usPremium(), RFC3966))
+	// Numbers with all zeros in the national number part will be formatted by using the raw_input
+	// if that is available no matter which format is specified.
+	assert.Equal(t, "000-000-0000", Format(usSpoofWithRawInput(), NATIONAL))
+	assert.Equal(t, "0", Format(usSpoof(), NATIONAL))
+}
+
+func TestFormatBSNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "242 365 1234", Format(bsNumber(), NATIONAL))
+	assert.Equal(t, "+1 242 365 1234", Format(bsNumber(), INTERNATIONAL))
+}
+
+func TestFormatGBNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "(020) 7031 3000", Format(gbNumber(), NATIONAL))
+	assert.Equal(t, "+44 20 7031 3000", Format(gbNumber(), INTERNATIONAL))
+
+	assert.Equal(t, "(07912) 345 678", Format(gbMobile(), NATIONAL))
+	assert.Equal(t, "+44 7912 345 678", Format(gbMobile(), INTERNATIONAL))
+}
+
+func TestFormatDENumber(t *testing.T) {
+	useTestMetadata(t)
+
+	deNumber := pn(49, 301234)
+	assert.Equal(t, "030/1234", Format(deNumber, NATIONAL))
+	assert.Equal(t, "+49 30/1234", Format(deNumber, INTERNATIONAL))
+	assert.Equal(t, "tel:+49-30-1234", Format(deNumber, RFC3966))
+
+	deNumber = pn(49, 291123)
+	assert.Equal(t, "0291 123", Format(deNumber, NATIONAL))
+	assert.Equal(t, "+49 291 123", Format(deNumber, INTERNATIONAL))
+
+	deNumber = pn(49, 29112345678)
+	assert.Equal(t, "0291 12345678", Format(deNumber, NATIONAL))
+	assert.Equal(t, "+49 291 12345678", Format(deNumber, INTERNATIONAL))
+
+	deNumber = pn(49, 912312345)
+	assert.Equal(t, "09123 12345", Format(deNumber, NATIONAL))
+	assert.Equal(t, "+49 9123 12345", Format(deNumber, INTERNATIONAL))
+
+	deNumber = pn(49, 80212345)
+	assert.Equal(t, "08021 2345", Format(deNumber, NATIONAL))
+	assert.Equal(t, "+49 8021 2345", Format(deNumber, INTERNATIONAL))
+	// Note this number is correctly formatted without national prefix. Most of the numbers that
+	// are treated as invalid numbers by the library are short numbers, and they are usually not
+	// dialed with national prefix.
+	assert.Equal(t, "1234", Format(deShortNumber(), NATIONAL))
+	assert.Equal(t, "+49 1234", Format(deShortNumber(), INTERNATIONAL))
+
+	deNumber = pn(49, 41341234)
+	assert.Equal(t, "04134 1234", Format(deNumber, NATIONAL))
+}
+
+func TestFormatITNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "02 3661 8300", Format(itNumber(), NATIONAL))
+	assert.Equal(t, "+39 02 3661 8300", Format(itNumber(), INTERNATIONAL))
+	assert.Equal(t, "+390236618300", Format(itNumber(), E164))
+
+	assert.Equal(t, "345 678 901", Format(itMobile(), NATIONAL))
+	assert.Equal(t, "+39 345 678 901", Format(itMobile(), INTERNATIONAL))
+	assert.Equal(t, "+39345678901", Format(itMobile(), E164))
+}
+
+func TestFormatAUNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "02 3661 8300", Format(auNumber(), NATIONAL))
+	assert.Equal(t, "+61 2 3661 8300", Format(auNumber(), INTERNATIONAL))
+	assert.Equal(t, "+61236618300", Format(auNumber(), E164))
+
+	auNumber := pn(61, 1800123456)
+	assert.Equal(t, "1800 123 456", Format(auNumber, NATIONAL))
+	assert.Equal(t, "+61 1800 123 456", Format(auNumber, INTERNATIONAL))
+	assert.Equal(t, "+611800123456", Format(auNumber, E164))
+}
+
+func TestFormatARNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "011 8765-4321", Format(arNumber(), NATIONAL))
+	assert.Equal(t, "+54 11 8765-4321", Format(arNumber(), INTERNATIONAL))
+	assert.Equal(t, "+541187654321", Format(arNumber(), E164))
+
+	assert.Equal(t, "011 15 8765-4321", Format(arMobile(), NATIONAL))
+	assert.Equal(t, "+54 9 11 8765 4321", Format(arMobile(), INTERNATIONAL))
+	assert.Equal(t, "+5491187654321", Format(arMobile(), E164))
+}
+
+func TestFormatMXNumber(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "045 234 567 8900", Format(mxMobile1(), NATIONAL))
+	assert.Equal(t, "+52 1 234 567 8900", Format(mxMobile1(), INTERNATIONAL))
+	assert.Equal(t, "+5212345678900", Format(mxMobile1(), E164))
+
+	assert.Equal(t, "045 55 1234 5678", Format(mxMobile2(), NATIONAL))
+	assert.Equal(t, "+52 1 55 1234 5678", Format(mxMobile2(), INTERNATIONAL))
+	assert.Equal(t, "+5215512345678", Format(mxMobile2(), E164))
+
+	assert.Equal(t, "01 33 1234 5678", Format(mxNumber1(), NATIONAL))
+	assert.Equal(t, "+52 33 1234 5678", Format(mxNumber1(), INTERNATIONAL))
+	assert.Equal(t, "+523312345678", Format(mxNumber1(), E164))
+
+	assert.Equal(t, "01 821 123 4567", Format(mxNumber2(), NATIONAL))
+	assert.Equal(t, "+52 821 123 4567", Format(mxNumber2(), INTERNATIONAL))
+	assert.Equal(t, "+528211234567", Format(mxNumber2(), E164))
+}
+
+func TestFormatByPattern(t *testing.T) {
+	useTestMetadata(t)
+
+	newNumFormat := &NumberFormat{
+		Pattern: proto.String("(\\d{3})(\\d{3})(\\d{4})"),
+		Format:  proto.String("($1) $2-$3"),
+	}
+	newNumberFormats := []*NumberFormat{newNumFormat}
+
+	assert.Equal(t, "(650) 253-0000", FormatByPattern(usNumber(), NATIONAL, newNumberFormats))
+	assert.Equal(t, "+1 (650) 253-0000", FormatByPattern(usNumber(), INTERNATIONAL, newNumberFormats))
+	usNumber2 := pn(1, 6507129823)
+	assert.Equal(t, "tel:+1-650-712-9823", FormatByPattern(usNumber2, RFC3966, newNumberFormats))
+
+	// $NP is set to '1' for the US. Here we check that for other NANPA countries the US rules are
+	// followed.
+	newNumFormat.NationalPrefixFormattingRule = proto.String("$NP ($FG)")
+	newNumFormat.Format = proto.String("$1 $2-$3")
+	newNumberFormats[0] = newNumFormat
+	assert.Equal(t, "1 (242) 365-1234", FormatByPattern(bsNumber(), NATIONAL, newNumberFormats))
+	assert.Equal(t, "+1 242 365-1234", FormatByPattern(bsNumber(), INTERNATIONAL, newNumberFormats))
+
+	newNumFormat.Pattern = proto.String("(\\d{2})(\\d{5})(\\d{3})")
+	newNumFormat.Format = proto.String("$1-$2 $3")
+	newNumberFormats[0] = newNumFormat
+
+	assert.Equal(t, "02-36618 300", FormatByPattern(itNumber(), NATIONAL, newNumberFormats))
+	assert.Equal(t, "+39 02-36618 300", FormatByPattern(itNumber(), INTERNATIONAL, newNumberFormats))
+
+	newNumFormat.NationalPrefixFormattingRule = proto.String("$NP$FG")
+	newNumFormat.Pattern = proto.String("(\\d{2})(\\d{4})(\\d{4})")
+	newNumFormat.Format = proto.String("$1 $2 $3")
+	newNumberFormats[0] = newNumFormat
+	assert.Equal(t, "020 7031 3000", FormatByPattern(gbNumber(), NATIONAL, newNumberFormats))
+
+	newNumFormat.NationalPrefixFormattingRule = proto.String("($NP$FG)")
+	newNumberFormats[0] = newNumFormat
+	assert.Equal(t, "(020) 7031 3000", FormatByPattern(gbNumber(), NATIONAL, newNumberFormats))
+
+	newNumFormat.NationalPrefixFormattingRule = proto.String("")
+	newNumberFormats[0] = newNumFormat
+	assert.Equal(t, "20 7031 3000", FormatByPattern(gbNumber(), NATIONAL, newNumberFormats))
+
+	assert.Equal(t, "+44 20 7031 3000", FormatByPattern(gbNumber(), INTERNATIONAL, newNumberFormats))
+}
+
+func TestFormatE164Number(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.Equal(t, "+16502530000", Format(usNumber(), E164))
+	assert.Equal(t, "+4930123456", Format(deNumber(), E164))
+	assert.Equal(t, "+80012345678", Format(internationalTollFree(), E164))
+}
+
+func TestFormatNumberWithExtension(t *testing.T) {
+	useTestMetadata(t)
+
+	nzNumber := nzNumber()
+	nzNumber.Extension = proto.String("1234")
+	// Uses default extension prefix:
+	assert.Equal(t, "03-331 6005 ext. 1234", Format(nzNumber, NATIONAL))
+	// Uses RFC 3966 syntax.
+	assert.Equal(t, "tel:+64-3-331-6005;ext=1234", Format(nzNumber, RFC3966))
+	// Extension prefix overridden in the territory information for the US:
+	usNumberWithExtension := usNumber()
+	usNumberWithExtension.Extension = proto.String("4567")
+	assert.Equal(t, "650 253 0000 extn. 4567", Format(usNumberWithExtension, NATIONAL))
+}
+
+func TestCountryWithNoNumberDesc(t *testing.T) {
+	useTestMetadata(t)
+
+	// Andorra is a country where we don't have PhoneNumberDesc info in the metadata.
+	adNumber := pn(376, 12345)
+	assert.Equal(t, "+376 12345", Format(adNumber, INTERNATIONAL))
+	assert.Equal(t, "+37612345", Format(adNumber, E164))
+	assert.Equal(t, "12345", Format(adNumber, NATIONAL))
+	assert.Equal(t, UNKNOWN, GetNumberType(adNumber))
+	assert.False(t, IsValidNumber(adNumber))
+
+	// Test dialing a US number from within Andorra.
+	assert.Equal(t, "00 1 650 253 0000", FormatOutOfCountryCallingNumber(usNumber(), regionCode.AD))
+}
+
+func TestUnknownCountryCallingCode(t *testing.T) {
+	useTestMetadata(t)
+
+	assert.False(t, IsValidNumber(unknownCountryCodeNoRawInput()))
+	// It's not very well defined as to what the E164 representation for a number with an invalid
+	// country calling code is, but just prefixing the country code and national number is about
+	// the best we can do.
+	assert.Equal(t, "+212345", Format(unknownCountryCodeNoRawInput(), E164))
+}


### PR DESCRIPTION
Ports upstream's `PhoneNumberUtilTest` formatting tests against the synthetic test metadata, verified faithfully against the current (post-#234) formatter. Done in a dedicated `git worktree` — no shared-checkout interference.

## Ported so far (17 methods, all faithful)
- **Basic:** `testFormat{US,BS,GB,DE,IT,AU,AR,MX}Number`, `testFormatByPattern`, `testFormatE164Number`, `testFormatNumberWithExtension`, `testCountryWithNoNumberDesc`, `testUnknownCountryCallingCode`
- **Out-of-country / carrier:** `testFormatOutOfCountryCallingNumber`, `testFormatOutOfCountryWithInvalidRegion`, `testFormatOutOfCountryWithPreferredIntlPrefix`, `testFormatWithPreferredCarrierCode`

Removes the ad-hoc real-metadata tests these supersede. (`testFormatWithCarrierCode` is already covered by `TestFormatWithCarrierCodeTestMetadata` from #234.)

## One real bug fixed (surfaced by the SG out-of-country case)
`UNIQUE_INTERNATIONAL_PREFIX` was unanchored, so Go's partial `MatchString` treated a regex IDD prefix like `0[0-3][0-9]` as a "unique" prefix (matching its leading `0`) instead of falling back to international `+` formatting. Anchored with `^(?:...)$` to mirror Java's `Pattern.matches()`. `FormatOutOfCountryCallingNumber(IT, SG)` now returns `+39 02 3661 8300`; full suite unaffected.

## Still to come (final follow-up)
The three large methods — `testFormatOutOfCountryKeepingAlphaChars`, `testFormatNumberForMobileDialing`, `testFormatInOriginalFormat`.

## Verification
Full suite + `-race` pass. No public API change.