### PR TITLE
Align builder's absent-type representation with upstream ([-1] possible length)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -388,7 +388,7 @@ func populatePossibleLengthSets(data []*PhoneNumberDescE, lengths map[int32]bool
  * missing. For all other types, the parent description will only be used to fill in missing
  * components if the type has a partial definition. For example, if no "tollFree" element exists,
  * we assume there are no toll free numbers for that locale, and return a phone number description
- * with "NA" for both the national and possible number patterns. Note that the parent description
+ * with no national number data and [-1] for the possible lengths. Note that the parent description
  * must therefore already be processed before this method is called on any child elements.
  *
  * @param parentDesc  a generic phone number description that will be used to fill in missing
@@ -403,7 +403,10 @@ func populatePossibleLengthSets(data []*PhoneNumberDescE, lengths map[int32]bool
 func processPhoneNumberDescElement(parentDesc *PhoneNumberDesc, element *PhoneNumberDescE) *PhoneNumberDesc {
 	numberDesc := PhoneNumberDesc{}
 	if element == nil {
-		numberDesc.NationalNumberPattern = sp("NA")
+		// -1 will never match a possible phone number length, so is safe to use to ensure this
+		// never matches. We don't leave it empty, since for compression reasons, we use the empty
+		// list to mean that the generalDesc possible lengths apply.
+		numberDesc.PossibleLength = []int32{-1}
 		return &numberDesc
 	}
 	if parentDesc != nil {

--- a/docs/PORT_STATUS.md
+++ b/docs/PORT_STATUS.md
@@ -34,8 +34,8 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
   invalid-number error table, keep-raw, phone-context)
 - ✅ Formatting (per-country, by-pattern, out-of-country, carrier, mobile-dialing,
   in-original-format)
-- Remaining: 2 skipped absent-type tests (see TODO below), the 2 Mockito
-  missing-metadata tests, and a couple of string-overload possibility cases.
+- Remaining: the 2 Mockito missing-metadata tests, and a couple of
+  string-overload possibility cases.
 
 ### Bugs the port surfaced and fixed
 - Builder nil-deref on regions lacking a mobile / fixed-line pattern
@@ -44,38 +44,39 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
   dropped for every region)
 - `$FG` / national-prefix formatting-rule application
 - `UNIQUE_INTERNATIONAL_PREFIX` unanchored (out-of-country IDD prefix resolution)
+- Absent-type metadata representation: the builder now marks a type with no
+  numbers using `possibleLength = [-1]` (matching upstream) instead of an `"NA"`
+  national pattern, so `testNumberLength` reports `INVALID_LENGTH` for
+  unsupported types. `descHasPossibleNumberData` was aligned with upstream
+  (empty ⇒ inherits general desc; `[-1]` ⇒ unsupported) while still treating the
+  legacy `"NA"` sentinel in the committed embedded metadata as "no data".
 
 ## Remaining work (roughly in order)
 
-1. **Absent-type metadata representation** (see TODO). Small; unblocks 2 tests and
-   removes a divergence.
-2. **Port `ShortNumberInfoTest`** (`shortnumberinfo_test.go` is still ad-hoc).
+1. **Port `ShortNumberInfoTest`** (`shortnumberinfo_test.go` is still ad-hoc).
    Open question: upstream `resources/` has no `ShortNumberMetadataForTesting.xml`
    — confirm how upstream's `ShortNumberInfoTest` sources its test metadata before
    porting.
-3. **Implement `AsYouTypeFormatter`** (currently absent) and port
+2. **Implement `AsYouTypeFormatter`** (currently absent) and port
    `AsYouTypeFormatterTest`.
-4. **Implement `PhoneNumberMatcher` / `findNumbers`** (currently a `nil` stub in
+3. **Implement `PhoneNumberMatcher` / `findNumbers`** (currently a `nil` stub in
    `phonenumbermatcher.go`) and port `PhoneNumberMatcherTest`.
-5. **Add `ExampleNumbersTest`** — a real-metadata regression that validates every
+4. **Add `ExampleNumbersTest`** — a real-metadata regression that validates every
    shipped region's example numbers parse and validate.
-6. **Automate**: a scheduled task that detects new upstream releases, regenerates
+5. **Automate**: a scheduled task that detects new upstream releases, regenerates
    metadata, runs the (now-stable) synthetic tests, opens a PR for data-only
    deltas, and flags logic-touching changes for manual porting. See
    `docs/2.0-restructure.md`.
 
 ## Known TODOs / documented divergences
 
-- **Absent-type representation.** Upstream marks a type with no numbers using
-  `possibleLength = [-1]` (so `testNumberLength` returns `INVALID_LENGTH`); this
-  builder instead leaves `possibleLength` empty with an `"NA"` pattern, so
-  unsupported types fall back to the general desc's lengths. Aligning it un-skips
-  `testIsPossibleNumberForType[WithReason]_NumberTypeNotSupportedForRegion` in
-  `phonenumberutil_types_test.go` and removes the `"NA"` assertion in
-  `TestGetInstanceLoadUSMetadata`. A naive fix (set `[-1]` in
-  `processPhoneNumberDescElement` for absent elements) has subtle
-  `FIXED_LINE_OR_MOBILE`-merge interactions in `testNumberLength`; it needs care
-  plus full-suite verification.
+- **Embedded metadata still uses the legacy `"NA"` sentinel.** The builder now
+  emits `possibleLength = [-1]` for absent types (matching upstream), but the
+  committed `data/metadata.xml.gz` was generated before that change and still
+  marks absent types with an `"NA"` national pattern. `descHasData` /
+  `descHasPossibleNumberData` handle both representations, so behaviour is
+  correct; the `"NA"` special-cases become dead code only once the embedded
+  metadata is regenerated (a separate data-refresh concern — see item 5).
 - **Parsing edge cases:** `normalizeDigits` doesn't map non-ASCII / non-Arabic
   unicode digits (e.g. Mongolian) to ASCII; the extension regex doesn't tolerate
   trailing whitespace after the extension digits. Both are characterized in the

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -835,8 +835,10 @@ var allPhoneNumberTypes = []PhoneNumberType{
 }
 
 // descHasData returns true if there is any data set for a particular
-// PhoneNumberDesc. Note: our builder represents an absent descriptor with the
-// "NA" sentinel pattern (see builder.go), so a pattern of "NA" counts as no data.
+// PhoneNumberDesc. The builder marks an absent descriptor with possibleLength
+// [-1] (matching upstream), but the committed embedded metadata still uses the
+// legacy "NA" national-number-pattern sentinel, so a pattern of "NA" also counts
+// as no data.
 func descHasData(desc *PhoneNumberDesc) bool {
 	if desc == nil {
 		return false
@@ -2171,8 +2173,17 @@ func IsPossibleNumber(number *PhoneNumber) bool {
 	return possible == IS_POSSIBLE || possible == IS_POSSIBLE_LOCAL_ONLY
 }
 
+// descHasPossibleNumberData returns true if there is any possible-length data
+// set for a PhoneNumberDesc. An empty possibleLength means numbers of this type
+// inherit from the general desc (so the type is supported); a single -1 entry
+// means no numbers exist for the type. The committed embedded metadata still
+// marks absent types with the legacy "NA" national-number pattern (and an empty
+// possibleLength) instead, so we treat that as no data too.
 func descHasPossibleNumberData(desc *PhoneNumberDesc) bool {
-	return len(desc.PossibleLength) > 0 && desc.PossibleLength[0] != -1
+	if desc.GetNationalNumberPattern() == "NA" {
+		return false
+	}
+	return len(desc.PossibleLength) != 1 || desc.PossibleLength[0] != -1
 }
 
 func mergeLengths(l1 []int32, l2 []int32) []int32 {

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -128,13 +128,9 @@ func TestGetInstanceLoadUSMetadata(t *testing.T) {
 	// separately in the toll free element as well.
 	assert.Len(t, metadata.GetTollFree().GetPossibleLength(), 0)
 	assert.Equal(t, `900\d{7}`, metadata.GetPremiumRate().GetNationalNumberPattern())
-	// No shared-cost data is available for US. Upstream leaves the descriptor
-	// unset (hasNationalNumberPattern() == false); our builder instead emits the
-	// legacy "NA" sentinel (matches nothing) for an absent descriptor — a known,
-	// functionally-equivalent divergence in metadata generation.
-	// TODO: align the builder's "NA" convention with upstream and restore
-	// assert.Empty here.
-	assert.Equal(t, "NA", metadata.GetSharedCost().GetNationalNumberPattern())
+	// No shared-cost data is available for US, so its national number data should
+	// not be set (the builder marks the absent descriptor with possibleLength [-1]).
+	assert.Nil(t, metadata.GetSharedCost().NationalNumberPattern) // hasNationalNumberPattern() == false
 }
 
 func TestGetInstanceLoadDEMetadata(t *testing.T) {

--- a/phonenumberutil_types_test.go
+++ b/phonenumberutil_types_test.go
@@ -112,14 +112,6 @@ func TestIsPossibleNumberForTypeDataMissingForSizeReasons(t *testing.T) {
 }
 
 func TestIsPossibleNumberForTypeNumberTypeNotSupportedForRegion(t *testing.T) {
-	// SKIP: depends on the absent-type metadata representation. Upstream marks a
-	// type with no numbers using possibleLength [-1] so testNumberLength returns
-	// INVALID_LENGTH; our builder instead leaves possibleLength empty (with an "NA"
-	// pattern), so unsupported types fall back to the general desc's lengths. This
-	// needs the builder's absent-type convention aligned with upstream (a separate,
-	// metadata-representation change). The IsPossibleNumberForType API itself is
-	// exercised by the other (passing) tests in this file.
-	t.Skip("blocked on absent-type metadata representation (NA vs possibleLength[-1])")
 	useTestMetadata(t)
 	number := &PhoneNumber{CountryCode: proto.Int32(55), NationalNumber: proto.Uint64(12345678)}
 	// There are *no* mobile numbers for this region at all, so we return false.
@@ -192,11 +184,6 @@ func TestIsPossibleNumberForTypeWithReasonDataMissingForSizeReasons(t *testing.T
 }
 
 func TestIsPossibleNumberForTypeWithReasonNumberTypeNotSupportedForRegion(t *testing.T) {
-	// SKIP: same underlying divergence as TestIsPossibleNumberForTypeNumberType
-	// NotSupportedForRegion — our builder represents an absent type with an empty
-	// possibleLength (+ "NA" pattern) rather than upstream's possibleLength [-1],
-	// so testNumberLength can't return INVALID_LENGTH for unsupported types.
-	t.Skip("blocked on absent-type metadata representation (NA vs possibleLength[-1])")
 	useTestMetadata(t)
 	// There are *no* mobile numbers for this region at all, so we return INVALID_LENGTH.
 	number := &PhoneNumber{CountryCode: proto.Int32(55), NationalNumber: proto.Uint64(12345678)}


### PR DESCRIPTION
## Summary

Aligns the metadata builder's representation of an *absent* number type with upstream libphonenumber and un-skips the two tests that were blocked on it.

Upstream marks a number type that has no numbers with `possibleLength = [-1]`, so `testNumberLength` reports `INVALID_LENGTH` for unsupported types. This builder instead emitted an `"NA"` national pattern with an empty `possibleLength`, so unsupported types fell back to the general description's lengths — a divergence that left two ported tests skipped.

## Changes

- **`builder.go`** — `processPhoneNumberDescElement` now sets `PossibleLength = [-1]` for an absent descriptor (and no `"NA"` national pattern), matching upstream's `processPhoneNumberDescElement` exactly.
- **`phonenumberutil.go`** — `descHasPossibleNumberData` adopts upstream's semantics (`count != 1 || [0] != -1`): an empty `possibleLength` means the type inherits the general desc and *is* supported, while `[-1]` means unsupported. It still treats the legacy `"NA"` sentinel as "no data", so the **committed embedded metadata keeps working** until it is regenerated (a separate data-refresh concern). This was needed because a type whose lengths match the general desc stores an empty `possibleLength`, and the old check wrongly treated that as "no data" — breaking the `FIXED_LINE_OR_MOBILE` merge path.
- **Tests** — un-skip `TestIsPossibleNumberForTypeNumberTypeNotSupportedForRegion` and `TestIsPossibleNumberForTypeWithReasonNumberTypeNotSupportedForRegion`; restore the faithful upstream assertion in `TestGetInstanceLoadUSMetadata` (`assertFalse(hasNationalNumberPattern())` → `assert.Nil`).
- **`docs/PORT_STATUS.md`** — mark the item done and record the remaining (data-only) follow-up.

## Verification

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, and `go test -race ./...` all pass — the full suite, including the real-metadata ad-hoc tests, so the change is confirmed not to regress behaviour against the committed embedded metadata.
