### PR TITLE
Implement ShortNumberInfo cost/carrier/SMS API and port ShortNumberInfoTest

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -571,6 +571,7 @@ func setRelevantDescPatterns(metadata *PhoneMetadata, element *TerritoryE, isSho
 		metadata.Emergency = processPhoneNumberDescElement(generalDesc, element.Emergency)
 		metadata.TollFree = processPhoneNumberDescElement(generalDesc, element.TollFree)
 		metadata.PremiumRate = processPhoneNumberDescElement(generalDesc, element.PremiumRate)
+		metadata.SmsServices = processPhoneNumberDescElement(generalDesc, element.SMSServices)
 	}
 }
 
@@ -680,6 +681,9 @@ type TerritoryE struct {
 
 	// <!ELEMENT voicemail (nationalNumberPattern, possibleLengths, exampleNumber)>
 	CarrierSpecific *PhoneNumberDescE `xml:"carrierSpecific"`
+
+	// <!ELEMENT smsServices (nationalNumberPattern, possibleLengths, exampleNumber)>
+	SMSServices *PhoneNumberDescE `xml:"smsServices"`
 }
 
 // <!ELEMENT numberFormat (leadingDigits*, format, intlFormat*)>

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,50 @@
+package phonenumbers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuilderProcessesSmsServices verifies the short-number metadata builder now
+// reads the <smsServices> element (it was previously dropped, leaving
+// IsSmsServiceForRegion non-functional). Exercised through the builder directly
+// since the committed embedded short metadata predates this fix and carries no
+// smsServices data.
+func TestBuilderProcessesSmsServices(t *testing.T) {
+	const shortXML = `<?xml version="1.0" encoding="UTF-8"?>
+<phoneNumberMetadata>
+  <territories>
+    <territory id="US" countryCode="1">
+      <generalDesc>
+        <nationalNumberPattern>[1-9]\d{2,5}</nationalNumberPattern>
+      </generalDesc>
+      <shortCode>
+        <possibleLengths national="[3-6]"/>
+        <exampleNumber>112</exampleNumber>
+        <nationalNumberPattern>[2-9]\d{2,5}</nationalNumberPattern>
+      </shortCode>
+      <smsServices>
+        <possibleLengths national="5,6"/>
+        <exampleNumber>20000</exampleNumber>
+        <nationalNumberPattern>[2-9]\d{4,5}</nationalNumberPattern>
+      </smsServices>
+    </territory>
+  </territories>
+</phoneNumberMetadata>`
+
+	coll, err := BuildPhoneMetadataCollection([]byte(shortXML), false, false, true)
+	require.NoError(t, err)
+	require.Len(t, coll.GetMetadata(), 1)
+
+	us := coll.GetMetadata()[0]
+	sms := us.GetSmsServices()
+	require.NotNil(t, sms)
+	assert.Equal(t, `[2-9]\d{4,5}`, sms.GetNationalNumberPattern())
+	assert.Equal(t, []int32{5, 6}, sms.GetPossibleLength())
+
+	// And the matching helper used by IsSmsServiceForRegion now finds it.
+	assert.True(t, matchesPossibleNumberAndNationalNumber("21234", sms))
+	assert.False(t, matchesPossibleNumberAndNationalNumber("112", sms))
+}

--- a/docs/PORT_STATUS.md
+++ b/docs/PORT_STATUS.md
@@ -37,6 +37,18 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
 - Remaining: the 2 Mockito missing-metadata tests, and a couple of
   string-overload possibility cases.
 
+### ShortNumberInfoTest — ported
+- ✅ Faithful port in `shortnumberinfo_test.go`, reconciled against v9.0.32.
+  Open question resolved: upstream has **no** `ShortNumberMetadataForTesting.xml`
+  because `ShortNumberInfo.getInstance()` uses the production short metadata; only
+  its `parse()` uses test metadata. The Go port therefore runs against the
+  embedded short metadata (a real-metadata regression, like upstream).
+- New public API implemented to support the port: `GetExpectedCost` /
+  `GetExpectedCostForRegion` (+ the `ShortNumberCost` type), `IsCarrierSpecific` /
+  `IsCarrierSpecificForRegion`, `IsSmsServiceForRegion`, and the
+  `getExampleShortNumber[ForCost]` helpers.
+- One skipped test: `TestIsSmsService` (see TODO below).
+
 ### Bugs the port surfaced and fixed
 - Builder nil-deref on regions lacking a mobile / fixed-line pattern
 - `GetNationalSignificantNumber` panic on a negative `numberOfLeadingZeros`
@@ -50,20 +62,21 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
   unsupported types. `descHasPossibleNumberData` was aligned with upstream
   (empty ⇒ inherits general desc; `[-1]` ⇒ unsupported) while still treating the
   legacy `"NA"` sentinel in the committed embedded metadata as "no data".
+- Short-number builder dropped `<smsServices>`: the short-metadata branch of
+  `setRelevantDescPatterns` never processed the element, so `IsSmsServiceForRegion`
+  could never match. The builder now reads it (verified by
+  `TestBuilderProcessesSmsServices`); the embedded data still needs regenerating
+  for it to carry the data (see TODO).
 
 ## Remaining work (roughly in order)
 
-1. **Port `ShortNumberInfoTest`** (`shortnumberinfo_test.go` is still ad-hoc).
-   Open question: upstream `resources/` has no `ShortNumberMetadataForTesting.xml`
-   — confirm how upstream's `ShortNumberInfoTest` sources its test metadata before
-   porting.
-2. **Implement `AsYouTypeFormatter`** (currently absent) and port
+1. **Implement `AsYouTypeFormatter`** (currently absent) and port
    `AsYouTypeFormatterTest`.
-3. **Implement `PhoneNumberMatcher` / `findNumbers`** (currently a `nil` stub in
+2. **Implement `PhoneNumberMatcher` / `findNumbers`** (currently a `nil` stub in
    `phonenumbermatcher.go`) and port `PhoneNumberMatcherTest`.
-4. **Add `ExampleNumbersTest`** — a real-metadata regression that validates every
+3. **Add `ExampleNumbersTest`** — a real-metadata regression that validates every
    shipped region's example numbers parse and validate.
-5. **Automate**: a scheduled task that detects new upstream releases, regenerates
+4. **Automate**: a scheduled task that detects new upstream releases, regenerates
    metadata, runs the (now-stable) synthetic tests, opens a PR for data-only
    deltas, and flags logic-touching changes for manual porting. See
    `docs/2.0-restructure.md`.
@@ -76,7 +89,11 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
   marks absent types with an `"NA"` national pattern. `descHasData` /
   `descHasPossibleNumberData` handle both representations, so behaviour is
   correct; the `"NA"` special-cases become dead code only once the embedded
-  metadata is regenerated (a separate data-refresh concern — see item 5).
+  metadata is regenerated (a separate data-refresh concern — see the automate item).
+- **`TestIsSmsService` is skipped.** `IsSmsServiceForRegion` is implemented and the
+  builder now reads `<smsServices>`, but the committed embedded short metadata was
+  generated before that builder support, so it carries no smsServices data and the
+  test would always see `false`. Un-skips once the short metadata is regenerated.
 - **Parsing edge cases:** `normalizeDigits` doesn't map non-ASCII / non-Arabic
   unicode digits (e.g. Mongolian) to ASCII; the extension regex doesn't tolerate
   trailing whitespace after the extension digits. Both are characterized in the

--- a/shortnumberinfo.go
+++ b/shortnumberinfo.go
@@ -71,6 +71,31 @@ func loadShortNumberMetadataFromFile() error {
 	return nil
 }
 
+// ShortNumberCost is the cost category of a short number.
+type ShortNumberCost int
+
+// Cost categories of short numbers. Note these are suffixed with _COST to avoid
+// clashing with the PhoneNumberType constants TOLL_FREE and PREMIUM_RATE.
+const (
+	TOLL_FREE_COST ShortNumberCost = iota
+	STANDARD_RATE_COST
+	PREMIUM_RATE_COST
+	UNKNOWN_COST
+)
+
+func (c ShortNumberCost) String() string {
+	switch c {
+	case TOLL_FREE_COST:
+		return "TOLL_FREE"
+	case STANDARD_RATE_COST:
+		return "STANDARD_RATE"
+	case PREMIUM_RATE_COST:
+		return "PREMIUM_RATE"
+	default:
+		return "UNKNOWN_COST"
+	}
+}
+
 // Check whether a short number is a possible number. If a country calling code is shared by
 // multiple regions, this returns true if it's possible in any of them. This provides a more
 // lenient check than #isValidShortNumber.
@@ -138,6 +163,85 @@ func IsValidShortNumberForRegion(number *PhoneNumber, regionDialingFrom string) 
 	return matchesPossibleNumberAndNationalNumber(shortNumber, shortNumberDesc)
 }
 
+// GetExpectedCostForRegion gets the expected cost category of a short number when dialed from a
+// region (however, nothing is implied about its validity). If it is important that the number is
+// valid, then its validity must first be checked using IsValidShortNumberForRegion. Note that
+// emergency numbers are always considered toll-free. Returns UNKNOWN_COST if the number does not
+// match a cost category. Note that an invalid number may match any cost category.
+func GetExpectedCostForRegion(number *PhoneNumber, regionDialingFrom string) ShortNumberCost {
+	if !regionDialingFromMatchesNumber(number, regionDialingFrom) {
+		return UNKNOWN_COST
+	}
+	// Note that regionDialingFrom may be empty, in which case phoneMetadata will also be nil.
+	phoneMetadata := getShortNumberMetadataForRegion(regionDialingFrom)
+	if phoneMetadata == nil {
+		return UNKNOWN_COST
+	}
+
+	shortNumber := GetNationalSignificantNumber(number)
+
+	// The possible lengths are not present for a particular sub-type if they match the general
+	// description; for this reason, we check the possible lengths against the general description
+	// first to allow an early exit if possible.
+	if !phoneMetadata.GetGeneralDesc().hasPossibleLength(int32(len(shortNumber))) {
+		return UNKNOWN_COST
+	}
+
+	// The cost categories are tested in order of decreasing expense, since if for some reason the
+	// patterns overlap the most expensive matching cost category should be returned.
+	if matchesPossibleNumberAndNationalNumber(shortNumber, phoneMetadata.GetPremiumRate()) {
+		return PREMIUM_RATE_COST
+	}
+	if matchesPossibleNumberAndNationalNumber(shortNumber, phoneMetadata.GetStandardRate()) {
+		return STANDARD_RATE_COST
+	}
+	if matchesPossibleNumberAndNationalNumber(shortNumber, phoneMetadata.GetTollFree()) {
+		return TOLL_FREE_COST
+	}
+	if IsEmergencyNumber(shortNumber, regionDialingFrom) {
+		// Emergency numbers are implicitly toll-free.
+		return TOLL_FREE_COST
+	}
+	return UNKNOWN_COST
+}
+
+// GetExpectedCost gets the expected cost category of a short number (however, nothing is implied
+// about its validity). If the country calling code is unique to a region, this method behaves
+// exactly the same as GetExpectedCostForRegion. However, if the country calling code is shared by
+// multiple regions, then it returns the highest cost in the sequence PREMIUM_RATE, UNKNOWN_COST,
+// STANDARD_RATE, TOLL_FREE. The reason for the position of UNKNOWN_COST in this order is that if a
+// number is UNKNOWN_COST in one region but STANDARD_RATE or TOLL_FREE in another, its expected
+// cost cannot be estimated as one of the latter since it might be a PREMIUM_RATE number.
+//
+// Note: If the region from which the number is dialed is known, it is highly preferable to call
+// GetExpectedCostForRegion instead.
+func GetExpectedCost(number *PhoneNumber) ShortNumberCost {
+	regionCodes := GetRegionCodesForCountryCode(int(number.GetCountryCode()))
+	if len(regionCodes) == 0 {
+		return UNKNOWN_COST
+	}
+	if len(regionCodes) == 1 {
+		return GetExpectedCostForRegion(number, regionCodes[0])
+	}
+	cost := TOLL_FREE_COST
+	for _, regionCode := range regionCodes {
+		costForRegion := GetExpectedCostForRegion(number, regionCode)
+		switch costForRegion {
+		case PREMIUM_RATE_COST:
+			return PREMIUM_RATE_COST
+		case UNKNOWN_COST:
+			cost = UNKNOWN_COST
+		case STANDARD_RATE_COST:
+			if cost != UNKNOWN_COST {
+				cost = STANDARD_RATE_COST
+			}
+		case TOLL_FREE_COST:
+			// Do nothing.
+		}
+	}
+	return cost
+}
+
 func getShortNumberMetadataForRegion(regionCode string) *PhoneMetadata {
 	val, _ := readFromShortNumberRegionToMetadataMap(regionCode)
 	return val
@@ -157,6 +261,41 @@ func getRegionCodeForShortNumberFromRegionList(number *PhoneNumber, regionCodes 
 			// The number is valid for this region.
 			return regionCode
 		}
+	}
+	return ""
+}
+
+// getExampleShortNumber gets a valid short number for the specified region. Returns an empty
+// string when the metadata does not contain such information.
+func getExampleShortNumber(regionCode string) string {
+	phoneMetadata := getShortNumberMetadataForRegion(regionCode)
+	if phoneMetadata == nil {
+		return ""
+	}
+	return phoneMetadata.GetShortCode().GetExampleNumber()
+}
+
+// getExampleShortNumberForCost gets a valid short number for the specified cost category. Returns
+// an empty string when the metadata does not contain such information, or the cost is UNKNOWN_COST.
+func getExampleShortNumberForCost(regionCode string, cost ShortNumberCost) string {
+	phoneMetadata := getShortNumberMetadataForRegion(regionCode)
+	if phoneMetadata == nil {
+		return ""
+	}
+	var desc *PhoneNumberDesc
+	switch cost {
+	case TOLL_FREE_COST:
+		desc = phoneMetadata.GetTollFree()
+	case STANDARD_RATE_COST:
+		desc = phoneMetadata.GetStandardRate()
+	case PREMIUM_RATE_COST:
+		desc = phoneMetadata.GetPremiumRate()
+	default:
+		// UNKNOWN_COST numbers are computed by the process of elimination from the other cost
+		// categories.
+	}
+	if desc != nil {
+		return desc.GetExampleNumber()
 	}
 	return ""
 }
@@ -237,4 +376,45 @@ func IsEmergencyNumber(number string, regionCode string) bool {
 // return: whether the number might be used to connect to an emergency service in the given region
 func ConnectsToEmergencyNumber(number string, regionCode string) bool {
 	return matchesEmergencyNumber(number, regionCode, true)
+}
+
+// IsCarrierSpecific given a valid short number, determines whether it is carrier-specific (however,
+// nothing is implied about its validity). Carrier-specific numbers may connect to a different
+// end-point, or not connect at all, depending on the user's carrier. If it is important that the
+// number is valid, then its validity must first be checked using IsValidShortNumber or
+// IsValidShortNumberForRegion.
+func IsCarrierSpecific(number *PhoneNumber) bool {
+	regionCodes := GetRegionCodesForCountryCode(int(number.GetCountryCode()))
+	regionCode := getRegionCodeForShortNumberFromRegionList(number, regionCodes)
+	nationalNumber := GetNationalSignificantNumber(number)
+	phoneMetadata := getShortNumberMetadataForRegion(regionCode)
+	return phoneMetadata != nil &&
+		matchesPossibleNumberAndNationalNumber(nationalNumber, phoneMetadata.GetCarrierSpecific())
+}
+
+// IsCarrierSpecificForRegion given a valid short number, determines whether it is carrier-specific
+// when dialed from the given region (however, nothing is implied about its validity). Returns false
+// if the number doesn't match the region provided.
+func IsCarrierSpecificForRegion(number *PhoneNumber, regionDialingFrom string) bool {
+	if !regionDialingFromMatchesNumber(number, regionDialingFrom) {
+		return false
+	}
+	nationalNumber := GetNationalSignificantNumber(number)
+	phoneMetadata := getShortNumberMetadataForRegion(regionDialingFrom)
+	return phoneMetadata != nil &&
+		matchesPossibleNumberAndNationalNumber(nationalNumber, phoneMetadata.GetCarrierSpecific())
+}
+
+// IsSmsServiceForRegion given a valid short number, determines whether it is an SMS service
+// (however, nothing is implied about its validity). An SMS service is where the primary or only
+// intended usage is to receive and/or send text messages (SMSs). This includes MMS as MMS numbers
+// downgrade to SMS if the other party isn't MMS-capable. Returns false if the number doesn't match
+// the region provided.
+func IsSmsServiceForRegion(number *PhoneNumber, regionDialingFrom string) bool {
+	if !regionDialingFromMatchesNumber(number, regionDialingFrom) {
+		return false
+	}
+	phoneMetadata := getShortNumberMetadataForRegion(regionDialingFrom)
+	return phoneMetadata != nil &&
+		matchesPossibleNumberAndNationalNumber(GetNationalSignificantNumber(number), phoneMetadata.GetSmsServices())
 }

--- a/shortnumberinfo_test.go
+++ b/shortnumberinfo_test.go
@@ -1,16 +1,19 @@
 package phonenumbers
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 )
 
-////////// Copied from java-libphonenumber
-/**
- * Unit tests for ShortNumberInfo.java
- */
+// Faithful port of upstream libphonenumber's ShortNumberInfoTest.java.
+// Unlike PhoneNumberUtilTest, upstream's ShortNumberInfoTest has no synthetic
+// metadata file: ShortNumberInfo.getInstance() always uses the production short
+// metadata, so these run against the embedded short-number metadata (just like
+// upstream). They are therefore real-metadata regressions, not synthetic.
+// Last reconciled against: v9.0.32
 
 func TestIsPossibleShortNumber(t *testing.T) {
 	countryCode := int32(33)
@@ -74,23 +77,132 @@ func TestIsValidShortNumber(t *testing.T) {
 	assert.False(t, IsValidShortNumberForRegion(invalidNumber, "FR"))
 }
 
+func TestIsCarrierSpecific(t *testing.T) {
+	carrierSpecificNumber := &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(33669)}
+	assert.True(t, IsCarrierSpecific(carrierSpecificNumber))
+	assert.True(t, IsCarrierSpecificForRegion(parse(t, "33669", "US"), "US"))
+
+	notCarrierSpecificNumber := &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(911)}
+	assert.False(t, IsCarrierSpecific(notCarrierSpecificNumber))
+	assert.False(t, IsCarrierSpecificForRegion(parse(t, "911", "US"), "US"))
+
+	carrierSpecificNumberForSomeRegion := &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(211)}
+	assert.True(t, IsCarrierSpecific(carrierSpecificNumberForSomeRegion))
+	assert.True(t, IsCarrierSpecificForRegion(carrierSpecificNumberForSomeRegion, "US"))
+	assert.False(t, IsCarrierSpecificForRegion(carrierSpecificNumberForSomeRegion, "BB"))
+}
+
+func TestIsSmsService(t *testing.T) {
+	// SKIP: the committed embedded short metadata carries no smsServices data — it
+	// was generated before the builder learned to read the <smsServices> element
+	// (see builder.go and TestBuilderProcessesSmsServices). IsSmsServiceForRegion
+	// therefore returns false for every region against the embedded snapshot. This
+	// un-skips once the short metadata is regenerated (a separate data refresh).
+	t.Skip("blocked on short metadata predating smsServices builder support (needs data regen)")
+	smsServiceNumberForSomeRegion := &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(21234)}
+	assert.True(t, IsSmsServiceForRegion(smsServiceNumberForSomeRegion, "US"))
+	assert.False(t, IsSmsServiceForRegion(smsServiceNumberForSomeRegion, "BB"))
+}
+
+func TestGetExpectedCost(t *testing.T) {
+	premiumRateExample := getExampleShortNumberForCost("FR", PREMIUM_RATE_COST)
+	assert.Equal(t, PREMIUM_RATE_COST, GetExpectedCostForRegion(parse(t, premiumRateExample, "FR"), "FR"))
+	premiumRateNumber := &PhoneNumber{CountryCode: proto.Int32(33), NationalNumber: proto.Uint64(atoui(t, premiumRateExample))}
+	assert.Equal(t, PREMIUM_RATE_COST, GetExpectedCost(premiumRateNumber))
+
+	standardRateExample := getExampleShortNumberForCost("FR", STANDARD_RATE_COST)
+	assert.Equal(t, STANDARD_RATE_COST, GetExpectedCostForRegion(parse(t, standardRateExample, "FR"), "FR"))
+	standardRateNumber := &PhoneNumber{CountryCode: proto.Int32(33), NationalNumber: proto.Uint64(atoui(t, standardRateExample))}
+	assert.Equal(t, STANDARD_RATE_COST, GetExpectedCost(standardRateNumber))
+
+	tollFreeExample := getExampleShortNumberForCost("FR", TOLL_FREE_COST)
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCostForRegion(parse(t, tollFreeExample, "FR"), "FR"))
+	tollFreeNumber := &PhoneNumber{CountryCode: proto.Int32(33), NationalNumber: proto.Uint64(atoui(t, tollFreeExample))}
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCost(tollFreeNumber))
+
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCostForRegion(parse(t, "12345", "FR"), "FR"))
+	unknownCostNumber := &PhoneNumber{CountryCode: proto.Int32(33), NationalNumber: proto.Uint64(12345)}
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCost(unknownCostNumber))
+
+	// Test that an invalid number may nevertheless have a cost other than UNKNOWN_COST.
+	assert.False(t, IsValidShortNumberForRegion(parse(t, "116123", "FR"), "FR"))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCostForRegion(parse(t, "116123", "FR"), "FR"))
+	invalidNumber := &PhoneNumber{CountryCode: proto.Int32(33), NationalNumber: proto.Uint64(116123)}
+	assert.False(t, IsValidShortNumber(invalidNumber))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCost(invalidNumber))
+
+	// Test a nonexistent country code.
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCostForRegion(parse(t, "911", "US"), "ZZ"))
+	unknownCostNumber = &PhoneNumber{CountryCode: proto.Int32(123), NationalNumber: proto.Uint64(911)}
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCost(unknownCostNumber))
+}
+
+func TestGetExpectedCostForSharedCountryCallingCode(t *testing.T) {
+	// Test some numbers which have different costs in countries sharing the same country calling
+	// code. In Australia, 1234 is premium-rate, 1194 is standard-rate, and 733 is toll-free. These
+	// are not known to be valid numbers in the Christmas Islands.
+	ambiguousPremiumRateString := "1234"
+	ambiguousPremiumRateNumber := &PhoneNumber{CountryCode: proto.Int32(61), NationalNumber: proto.Uint64(1234)}
+	ambiguousStandardRateString := "1194"
+	ambiguousStandardRateNumber := &PhoneNumber{CountryCode: proto.Int32(61), NationalNumber: proto.Uint64(1194)}
+	ambiguousTollFreeString := "733"
+	ambiguousTollFreeNumber := &PhoneNumber{CountryCode: proto.Int32(61), NationalNumber: proto.Uint64(733)}
+
+	assert.True(t, IsValidShortNumber(ambiguousPremiumRateNumber))
+	assert.True(t, IsValidShortNumber(ambiguousStandardRateNumber))
+	assert.True(t, IsValidShortNumber(ambiguousTollFreeNumber))
+
+	assert.True(t, IsValidShortNumberForRegion(parse(t, ambiguousPremiumRateString, "AU"), "AU"))
+	assert.Equal(t, PREMIUM_RATE_COST, GetExpectedCostForRegion(parse(t, ambiguousPremiumRateString, "AU"), "AU"))
+	assert.False(t, IsValidShortNumberForRegion(parse(t, ambiguousPremiumRateString, "CX"), "CX"))
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCostForRegion(parse(t, ambiguousPremiumRateString, "CX"), "CX"))
+	// PREMIUM_RATE takes precedence over UNKNOWN_COST.
+	assert.Equal(t, PREMIUM_RATE_COST, GetExpectedCost(ambiguousPremiumRateNumber))
+
+	assert.True(t, IsValidShortNumberForRegion(parse(t, ambiguousStandardRateString, "AU"), "AU"))
+	assert.Equal(t, STANDARD_RATE_COST, GetExpectedCostForRegion(parse(t, ambiguousStandardRateString, "AU"), "AU"))
+	assert.False(t, IsValidShortNumberForRegion(parse(t, ambiguousStandardRateString, "CX"), "CX"))
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCostForRegion(parse(t, ambiguousStandardRateString, "CX"), "CX"))
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCost(ambiguousStandardRateNumber))
+
+	assert.True(t, IsValidShortNumberForRegion(parse(t, ambiguousTollFreeString, "AU"), "AU"))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCostForRegion(parse(t, ambiguousTollFreeString, "AU"), "AU"))
+	assert.False(t, IsValidShortNumberForRegion(parse(t, ambiguousTollFreeString, "CX"), "CX"))
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCostForRegion(parse(t, ambiguousTollFreeString, "CX"), "CX"))
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCost(ambiguousTollFreeNumber))
+}
+
+func TestExampleShortNumberPresence(t *testing.T) {
+	assert.NotEmpty(t, getExampleShortNumber("AD"))
+	assert.NotEmpty(t, getExampleShortNumber("FR"))
+	assert.Empty(t, getExampleShortNumber("001"))
+	assert.Empty(t, getExampleShortNumber(""))
+}
+
 func TestConnectsToEmergencyNumber_US(t *testing.T) {
 	assert.True(t, ConnectsToEmergencyNumber("911", "US"))
 	assert.True(t, ConnectsToEmergencyNumber("112", "US"))
 	assert.False(t, ConnectsToEmergencyNumber("999", "US"))
 }
 
-func TestConnectsToEmergencyLongNumber_US(t *testing.T) {
+func TestConnectsToEmergencyNumberLongNumber_US(t *testing.T) {
 	assert.True(t, ConnectsToEmergencyNumber("9116666666", "US"))
 	assert.True(t, ConnectsToEmergencyNumber("1126666666", "US"))
 	assert.False(t, ConnectsToEmergencyNumber("9996666666", "US"))
 }
 
 func TestConnectsToEmergencyNumberWithFormatting_US(t *testing.T) {
-
 	assert.True(t, ConnectsToEmergencyNumber("9-1-1", "US"))
 	assert.True(t, ConnectsToEmergencyNumber("1-1-2", "US"))
 	assert.False(t, ConnectsToEmergencyNumber("9-9-9", "US"))
+}
+
+func TestConnectsToEmergencyNumberWithPlusSign_US(t *testing.T) {
+	assert.False(t, ConnectsToEmergencyNumber("+911", "US"))
+	assert.False(t, ConnectsToEmergencyNumber("＋911", "US"))
+	assert.False(t, ConnectsToEmergencyNumber(" +911", "US"))
+	assert.False(t, ConnectsToEmergencyNumber("+112", "US"))
+	assert.False(t, ConnectsToEmergencyNumber("+999", "US"))
 }
 
 func TestConnectsToEmergencyNumber_BR(t *testing.T) {
@@ -181,26 +293,48 @@ func TestIsEmergencyNumber_ZW(t *testing.T) {
 }
 
 func TestEmergencyNumberForSharedCountryCallingCode(t *testing.T) {
+	// Test the emergency number 112, which is valid in both Australia and the Christmas Islands.
 	assert.True(t, IsEmergencyNumber("112", "AU"))
 	assert.True(t, IsValidShortNumberForRegion(parse(t, "112", "AU"), "AU"))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCostForRegion(parse(t, "112", "AU"), "AU"))
 	assert.True(t, IsEmergencyNumber("112", "CX"))
 	assert.True(t, IsValidShortNumberForRegion(parse(t, "112", "CX"), "CX"))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCostForRegion(parse(t, "112", "CX"), "CX"))
 	sharedEmergencyNumber := &PhoneNumber{
 		CountryCode:    proto.Int32(61),
 		NationalNumber: proto.Uint64(112),
 	}
 	assert.True(t, IsValidShortNumber(sharedEmergencyNumber))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCost(sharedEmergencyNumber))
 }
 
 func TestOverlappingNANPANumber(t *testing.T) {
+	// 211 is an emergency number in Barbados, while it is a toll-free information line in Canada
+	// and the USA.
 	assert.True(t, IsEmergencyNumber("211", "BB"))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCostForRegion(parse(t, "211", "BB"), "BB"))
 	assert.False(t, IsEmergencyNumber("211", "US"))
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCostForRegion(parse(t, "211", "US"), "US"))
 	assert.False(t, IsEmergencyNumber("211", "CA"))
+	assert.Equal(t, TOLL_FREE_COST, GetExpectedCostForRegion(parse(t, "211", "CA"), "CA"))
 }
 
 func TestCountryCallingCodeIsNotIgnored(t *testing.T) {
+	// +46 is the country calling code for Sweden (SE), and 40404 is a valid short number in the US.
 	assert.False(t, IsPossibleShortNumberForRegion(parse(t, "+4640404", "SE"), "US"))
 	assert.False(t, IsValidShortNumberForRegion(parse(t, "+4640404", "SE"), "US"))
+	assert.Equal(t, UNKNOWN_COST, GetExpectedCostForRegion(parse(t, "+4640404", "SE"), "US"))
+}
+
+// atoui parses a decimal string into a uint64, failing the test on error. Mirrors upstream's
+// Integer.parseInt usage on example short numbers.
+func atoui(t *testing.T, s string) uint64 {
+	t.Helper()
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		t.Fatalf("expected a numeric short number, got %q: %s", s, err)
+	}
+	return n
 }
 
 func parse(t *testing.T, number string, regionCode string) *PhoneNumber {


### PR DESCRIPTION
## Summary

Implements the public `ShortNumberInfo` methods that were missing and completes the port of upstream libphonenumber's `ShortNumberInfoTest`.

Upstream's `ShortNumberInfoTest` has **no** synthetic metadata file — `ShortNumberInfo.getInstance()` always uses the production short metadata (only its `parse()` uses test metadata). So these tests run against the embedded short-number metadata, exactly as upstream does.

## New public API (`shortnumberinfo.go`)

- `ShortNumberCost` (`TOLL_FREE_COST`, `STANDARD_RATE_COST`, `PREMIUM_RATE_COST`, `UNKNOWN_COST` — suffixed `_COST` to avoid clashing with the existing `TOLL_FREE`/`PREMIUM_RATE` `PhoneNumberType` constants)
- `GetExpectedCost` / `GetExpectedCostForRegion`
- `IsCarrierSpecific` / `IsCarrierSpecificForRegion`
- `IsSmsServiceForRegion`
- `getExampleShortNumber` / `getExampleShortNumberForCost` (unexported, mirroring upstream's package-private `@VisibleForTesting` helpers)

All ported faithfully from upstream `ShortNumberInfo.java`.

## Builder fix

The short-metadata branch of `setRelevantDescPatterns` never read the `<smsServices>` element, so `IsSmsServiceForRegion` could never match. The builder now processes it (added the `SMSServices` field on `TerritoryE` and the processing call), matching upstream. Verified by a new `builder_test.go` (`TestBuilderProcessesSmsServices`) that builds short metadata through `BuildPhoneMetadataCollection` and asserts the element is now read.

## Tests (`shortnumberinfo_test.go`)

Ports the remaining upstream methods — `IsCarrierSpecific`, `IsSmsService`, `GetExpectedCost`, `GetExpectedCostForSharedCountryCallingCode`, `ExampleShortNumberPresence`, and the two `WithPlusSign_US` cases — and adds the cost assertions upstream now includes in the shared / overlapping-NANPA / country-code tests. Reclassifies the file header from ad-hoc to a faithful port.

### One documented skip

`TestIsSmsService` is skipped: the implementation and builder support are in place, but the committed embedded short metadata predates the builder fix and carries no `smsServices` data, so the check always sees `false`. It un-skips after a short-metadata regeneration (a separate data-refresh concern). Documented in `docs/PORT_STATUS.md`.

## Verification

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race ./...`, and `gofmt` all clean. Every new test passes except the documented skip.
