### PR TITLE
Port remaining PhoneNumberUtilTest methods; fix UNWANTED_END_CHARS regex

### DIFF
--- a/docs/PORT_STATUS.md
+++ b/docs/PORT_STATUS.md
@@ -27,26 +27,24 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
 
 ## Status
 
-### PhoneNumberUtilTest — substantially ported
+### PhoneNumberUtilTest — ported (except 2 Mockito tests)
 - ✅ Metadata loading, region / country-code lookup, number type, validation,
-  example numbers, supported-types, possibility-by-type
+  example numbers, supported-types, possibility (incl. by-type, with-reason,
+  not-possible)
 - ✅ Parsing (national, international prefixes, non-ASCII, extensions, the
   invalid-number error table, keep-raw, phone-context, Italian leading zeros,
-  national-prefix stripping)
+  national-prefix / international-prefix stripping, country-code extraction)
 - ✅ Formatting (per-country, by-pattern, out-of-country, carrier, mobile-dialing,
   in-original-format)
 - ✅ Number matching — the full `testIsNumberMatch*` family (8 methods) in
   `phonenumberutil_isnumbermatch_test.go`
-- ⚠️ Still only covered by the **ad-hoc** tests (real embedded metadata, not
-  faithful synthetic-metadata ports — see `phonenumberutil_adhoc_test.go`), so a
-  faithful port is still owed for:
-  - `testIsPossibleNumber` / `testIsNotPossibleNumber` /
-    `testIsPossibleNumberWithReason` (the non-by-type possibility checks)
-  - `testTruncateTooLongNumber`, `testIsViablePhoneNumber` (+ `NonAscii`),
-    `testExtractPossibleNumber`
-  - the `testNormalise*` family and `testConvertAlphaCharactersInNumber`
-- Not ported at all yet: `testMaybeStripInternationalPrefix`,
-  `testMaybeExtractCountryCode`, and the 2 Mockito missing-metadata tests.
+- ✅ Normalization / viability / extraction (`testConvertAlphaCharactersInNumber`,
+  the `testNormalise*` family, `testIsViablePhoneNumber` (+ `NonAscii`),
+  `testExtractPossibleNumber`) in `phonenumberutil_normalize_test.go`; truncation
+  and possibility in `phonenumberutil_possibility_test.go`.
+- ⚠️ Not ported: only the 2 Mockito missing-metadata tests
+  (`testGetMetadataForRegionForMissingMetadata` and the non-geographical variant),
+  which rely on Mockito-style metadata-source injection.
 
 ### ShortNumberInfoTest — ported
 - ✅ Faithful port in `shortnumberinfo_test.go`, reconciled against v9.0.32.
@@ -76,6 +74,13 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
   every-type test uses a local helper (`getExampleNumberForTypeAnyRegion`).
 
 ### Bugs the port surfaced and fixed
+- `extractPossibleNumber` never trimmed trailing junk: `UNWANTED_END_CHARS` was
+  copied verbatim from Java (`[[\P{N}&&\P{L}]&&[^#]]+$`), but Go's RE2 engine has
+  no character-class intersection (`&&`), so the pattern compiled to something
+  meaningless and matched nothing. Rewrote it as the equivalent negated class
+  `[^\p{N}\p{L}#]+$`. This also resolved the documented trailing-whitespace
+  divergence in `testParseExtensions` (`"+44 2034567890 x 456  "` now extracts
+  extension `456` like upstream, instead of folding the digits into the NSN).
 - `IsNumberMatch` leading-zeros equality: the matcher compared the two numbers
   with `reflect.DeepEqual` on the raw protos instead of upstream's
   `copyCoreFieldsOnly` value comparison, so a `numberOfLeadingZeros` that was the
@@ -129,10 +134,9 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
   builder now reads `<smsServices>`, but the committed embedded short metadata was
   generated before that builder support, so it carries no smsServices data and the
   test would always see `false`. Un-skips once the short metadata is regenerated.
-- **Parsing edge cases:** `normalizeDigits` doesn't map non-ASCII / non-Arabic
-  unicode digits (e.g. Mongolian) to ASCII; the extension regex doesn't tolerate
-  trailing whitespace after the extension digits. Both are characterized in the
-  parsing tests.
+- **Parsing edge case:** `normalizeDigits` may not map every non-ASCII unicode
+  digit script (e.g. Mongolian) to ASCII; the Arabic-Indic, Eastern-Arabic and
+  fullwidth digits exercised by `TestNormaliseOtherDigits` do convert correctly.
 - `getExampleNumberForType` has no region-less overload; the relevant test uses a
   local helper.
 

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -298,7 +298,7 @@ var (
 	// We remove all characters that are not alpha or numerical characters.
 	// The hash character is retained here, as it may signify the previous
 	// block was an extension.
-	UNWANTED_END_CHARS        = "[[\\P{N}&&\\P{L}]&&[^#]]+$"
+	UNWANTED_END_CHARS        = "[^\\p{N}\\p{L}#]+$"
 	UNWANTED_END_CHAR_PATTERN = regexp.MustCompile(UNWANTED_END_CHARS)
 
 	// We use this pattern to check if the phone number has at least three

--- a/phonenumberutil_adhoc_test.go
+++ b/phonenumberutil_adhoc_test.go
@@ -26,21 +26,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestConvertAlphaCharactersInNumber(t *testing.T) {
-	var tests = []struct {
-		input, expected string
-	}{
-		{input: "1800AWWPOOP", expected: "18002997667"},
-		{input: "(800) DAW-ORLD", expected: "(800) 329-6753"},
-		{input: "1800-ABC-DEF", expected: "1800-222-333"},
-	}
-
-	for _, tc := range tests {
-		actual := ConvertAlphaCharactersInNumber(tc.input)
-		assert.Equal(t, tc.expected, actual, "mismatch for input %s", tc.input)
-	}
-}
-
 func TestNormalizeDigits(t *testing.T) {
 	var tests = []struct {
 		input         string
@@ -59,52 +44,6 @@ func TestNormalizeDigits(t *testing.T) {
 	}
 }
 
-func TestExtractPossibleNumber(t *testing.T) {
-	assert.Equal(t, "530) 583-6985 x302", extractPossibleNumber("(530) 583-6985 x302/x2303")) // yes, the leading '(' is missing
-}
-
-func TestIsViablePhoneNumber(t *testing.T) {
-	var tests = []struct {
-		input    string
-		isViable bool
-	}{
-		{input: "4445556666", isViable: true},
-		{input: "+441932123456", isViable: true},
-		{input: "4930123456", isViable: true},
-		{input: "2", isViable: false},
-		{input: "helloworld", isViable: false},
-	}
-
-	for _, tc := range tests {
-		actual := isViablePhoneNumber(tc.input)
-		assert.Equal(t, tc.isViable, actual, "mismatch for input %s", tc.input)
-	}
-}
-
-func TestNormalize(t *testing.T) {
-	var tests = []struct {
-		input    string
-		expected string
-	}{
-		{input: "4431234567", expected: "4431234567"},
-		{input: "443 1234567", expected: "4431234567"},
-		{input: "(443)123-4567", expected: "4431234567"},
-		{input: "800yoloFOO", expected: "8009656366"},
-		{input: "444111a2222", expected: "4441112222"},
-
-		// from libponenumber [java] unit tests
-		{input: "034-56&+#2\u00AD34", expected: "03456234"},
-		{input: "034-I-am-HUNGRY", expected: "034426486479"},
-		{input: "\uFF125\u0665", expected: "255"},
-		{input: "\u06F52\u06F0", expected: "520"},
-	}
-
-	for _, tc := range tests {
-		actual := normalize(tc.input)
-		assert.Equal(t, tc.expected, actual, "mismatch for input %s", tc.input)
-	}
-}
-
 func TestRepeatedParsing(t *testing.T) {
 	phoneNumbers := []string{"+917827202781", "+910000000000", "+910800125778", "+917503257232", "+917566482842"}
 
@@ -117,60 +56,6 @@ func TestRepeatedParsing(t *testing.T) {
 		assert.NoError(t, err, "unexpected error for input %s", n)
 
 		assert.Equal(t, IsValidNumber(num), IsValidNumber(number))
-	}
-}
-
-func TestIsPossibleNumberWithReason(t *testing.T) {
-	var tests = []struct {
-		input  string
-		region string
-		err    error
-		valid  ValidationResult
-	}{
-		{input: "16502530000", region: "US", err: nil, valid: IS_POSSIBLE},
-		{input: "2530000", region: "US", err: nil, valid: IS_POSSIBLE_LOCAL_ONLY},
-		{input: "65025300001", region: "US", err: nil, valid: TOO_LONG},
-		{input: "2530000", region: "", err: ErrInvalidCountryCode, valid: IS_POSSIBLE_LOCAL_ONLY},
-		{input: "253000", region: "US", err: nil, valid: TOO_SHORT},
-		{input: "1234567890", region: "SG", err: nil, valid: IS_POSSIBLE},
-		{input: "800123456789", region: "US", err: nil, valid: TOO_LONG},
-		{input: "+1456723456", region: "US", err: nil, valid: TOO_SHORT},
-		{input: "6041234567", region: "US", err: nil, valid: IS_POSSIBLE},
-		{input: "+2250749195919", region: "CI", err: nil, valid: IS_POSSIBLE},
-	}
-
-	for _, tc := range tests {
-		num, err := Parse(tc.input, tc.region)
-
-		if tc.err != nil {
-			assert.EqualError(t, err, tc.err.Error(), "error mismatch for input %s", tc.input)
-		} else {
-			assert.NoError(t, err, "unexpected error for input %s", tc.input)
-			assert.Equal(t, tc.valid, IsPossibleNumberWithReason(num), "mismatch for input %s", tc.input)
-		}
-	}
-}
-
-func TestTruncateTooLongNumber(t *testing.T) {
-	var tests = []struct {
-		country int
-		input   uint64
-		res     bool
-		output  uint64
-	}{
-		{country: 1, input: 80055501234, res: true, output: 8005550123},
-		{country: 1, input: 8005550123, res: true, output: 8005550123},
-		{country: 1, input: 800555012, res: false, output: 800555012},
-	}
-
-	for _, tc := range tests {
-		num := &PhoneNumber{}
-		num.CountryCode = proto.Int32(int32(tc.country))
-		num.NationalNumber = proto.Uint64(tc.input)
-		res := TruncateTooLongNumber(num)
-
-		assert.Equal(t, tc.res, res, "res mismatch for input %d", tc.input)
-		assert.Equal(t, tc.output, *num.NationalNumber, "output mismatch for input %d", tc.input)
 	}
 }
 
@@ -277,17 +162,6 @@ func TestGetMetadata(t *testing.T) {
 				i, len(meta.GetNumberFormat()), meta.GetNumberFormat(), test.numFmtSize)
 		}
 	}
-}
-
-func TestNormalizeDigitsOnly(t *testing.T) {
-	if NormalizeDigitsOnly("034-56&+a#234") != "03456234" {
-		t.Errorf("didn't fully normalize digits only")
-	}
-}
-
-func TestNormalizeDiallableCharsOnly(t *testing.T) {
-	// '#' is a diallable character and should be preserved
-	assert.Equal(t, "03*456+#234", normalizeDiallableCharsOnly("03*4-56&+a#234"))
 }
 
 type testCase struct {

--- a/phonenumberutil_normalize_test.go
+++ b/phonenumberutil_normalize_test.go
@@ -1,0 +1,99 @@
+package phonenumbers
+
+// Faithful port of upstream libphonenumber's PhoneNumberUtilTest.java
+// normalization / alpha / viability / extraction methods. These exercise static
+// helpers that don't touch metadata, so (unlike most ports) they don't call
+// useTestMetadata. Method names and assertions mirror the Java; non-ASCII
+// inputs use the same \u escapes as upstream. Last reconciled against: v9.0.32
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// testConvertAlphaCharactersInNumber (PhoneNumberUtilTest.java:446-451)
+func TestConvertAlphaCharactersInNumber(t *testing.T) {
+	input := "1800-ABC-DEF"
+	// Alpha chars are converted to digits; everything else is left untouched.
+	assert.Equal(t, "1800-222-333", ConvertAlphaCharactersInNumber(input))
+}
+
+// testNormaliseRemovePunctuation (PhoneNumberUtilTest.java:453-458)
+func TestNormaliseRemovePunctuation(t *testing.T) {
+	assert.Equal(t, "03456234", normalize("034-56&+#2­34"), "Conversion did not correctly remove punctuation")
+}
+
+// testNormaliseReplaceAlphaCharacters (PhoneNumberUtilTest.java:460-465)
+func TestNormaliseReplaceAlphaCharacters(t *testing.T) {
+	assert.Equal(t, "034426486479", normalize("034-I-am-HUNGRY"), "Conversion did not correctly replace alpha characters")
+}
+
+// testNormaliseOtherDigits (PhoneNumberUtilTest.java:467-478)
+func TestNormaliseOtherDigits(t *testing.T) {
+	assert.Equal(t, "255", normalize("２5٥"), "Conversion did not correctly replace non-latin digits")
+	// Eastern-Arabic digits.
+	assert.Equal(t, "520", normalize("۵2۰"), "Conversion did not correctly replace non-latin digits")
+}
+
+// testNormaliseStripAlphaCharacters (PhoneNumberUtilTest.java:479-485)
+func TestNormaliseStripAlphaCharacters(t *testing.T) {
+	assert.Equal(t, "03456234", NormalizeDigitsOnly("034-56&+a#234"), "Conversion did not correctly remove alpha character")
+}
+
+// testNormaliseStripNonDiallableCharacters (PhoneNumberUtilTest.java:487-493)
+func TestNormaliseStripNonDiallableCharacters(t *testing.T) {
+	assert.Equal(t, "03*456+1#234", normalizeDiallableCharsOnly("03*4-56&+1a#234"), "Conversion did not correctly remove non-diallable characters")
+}
+
+// testIsViablePhoneNumber (PhoneNumberUtilTest.java:1798-1813)
+func TestIsViablePhoneNumber(t *testing.T) {
+	assert.False(t, isViablePhoneNumber("1"))
+	// Only one or two digits before strange non-possible punctuation.
+	assert.False(t, isViablePhoneNumber("1+1+1"))
+	assert.False(t, isViablePhoneNumber("80+0"))
+	// Two digits is viable.
+	assert.True(t, isViablePhoneNumber("00"))
+	assert.True(t, isViablePhoneNumber("111"))
+	// Alpha numbers.
+	assert.True(t, isViablePhoneNumber("0800-4-pizza"))
+	assert.True(t, isViablePhoneNumber("0800-4-PIZZA"))
+	// We need at least three digits before any alpha characters.
+	assert.False(t, isViablePhoneNumber("08-PIZZA"))
+	assert.False(t, isViablePhoneNumber("8-PIZZA"))
+	assert.False(t, isViablePhoneNumber("12. March"))
+}
+
+// testIsViablePhoneNumberNonAscii (PhoneNumberUtilTest.java:1815-1823)
+func TestIsViablePhoneNumberNonAscii(t *testing.T) {
+	// Only one or two digits before possible punctuation followed by more digits.
+	assert.True(t, isViablePhoneNumber("1　34"))
+	assert.False(t, isViablePhoneNumber("1　3+4"))
+	// Unicode variants of possible starting character and other allowed punctuation/digits.
+	assert.True(t, isViablePhoneNumber("（1）　3456789"))
+	// Testing a leading + is okay.
+	assert.True(t, isViablePhoneNumber("+1）　3456789"))
+}
+
+// testExtractPossibleNumber (PhoneNumberUtilTest.java:1825-1847)
+func TestExtractPossibleNumber(t *testing.T) {
+	// Removes preceding funky punctuation and letters but leaves the rest untouched.
+	assert.Equal(t, "0800-345-600", extractPossibleNumber("Tel:0800-345-600"))
+	assert.Equal(t, "0800 FOR PIZZA", extractPossibleNumber("Tel:0800 FOR PIZZA"))
+	// Should not remove plus sign
+	assert.Equal(t, "+800-345-600", extractPossibleNumber("Tel:+800-345-600"))
+	// Should recognise wide digits as possible start values.
+	assert.Equal(t, "０２３", extractPossibleNumber("０２３"))
+	// Dashes are not possible start values and should be removed.
+	assert.Equal(t, "１２３", extractPossibleNumber("Num-１２３"))
+	// If not possible number present, return empty string.
+	assert.Equal(t, "", extractPossibleNumber("Num-...."))
+	// Leading brackets are stripped - these are not used when parsing.
+	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000"))
+
+	// Trailing non-alpha-numeric characters should be removed.
+	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000..- .."))
+	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000."))
+	// This case has a trailing RTL char.
+	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000‏"))
+}

--- a/phonenumberutil_normalize_test.go
+++ b/phonenumberutil_normalize_test.go
@@ -21,7 +21,7 @@ func TestConvertAlphaCharactersInNumber(t *testing.T) {
 
 // testNormaliseRemovePunctuation (PhoneNumberUtilTest.java:453-458)
 func TestNormaliseRemovePunctuation(t *testing.T) {
-	assert.Equal(t, "03456234", normalize("034-56&+#2­34"), "Conversion did not correctly remove punctuation")
+	assert.Equal(t, "03456234", normalize("034-56&+#2\u00AD34"), "Conversion did not correctly remove punctuation")
 }
 
 // testNormaliseReplaceAlphaCharacters (PhoneNumberUtilTest.java:460-465)
@@ -31,9 +31,9 @@ func TestNormaliseReplaceAlphaCharacters(t *testing.T) {
 
 // testNormaliseOtherDigits (PhoneNumberUtilTest.java:467-478)
 func TestNormaliseOtherDigits(t *testing.T) {
-	assert.Equal(t, "255", normalize("２5٥"), "Conversion did not correctly replace non-latin digits")
+	assert.Equal(t, "255", normalize("\uFF125\u0665"), "Conversion did not correctly replace non-latin digits")
 	// Eastern-Arabic digits.
-	assert.Equal(t, "520", normalize("۵2۰"), "Conversion did not correctly replace non-latin digits")
+	assert.Equal(t, "520", normalize("\u06F52\u06F0"), "Conversion did not correctly replace non-latin digits")
 }
 
 // testNormaliseStripAlphaCharacters (PhoneNumberUtilTest.java:479-485)
@@ -67,12 +67,12 @@ func TestIsViablePhoneNumber(t *testing.T) {
 // testIsViablePhoneNumberNonAscii (PhoneNumberUtilTest.java:1815-1823)
 func TestIsViablePhoneNumberNonAscii(t *testing.T) {
 	// Only one or two digits before possible punctuation followed by more digits.
-	assert.True(t, isViablePhoneNumber("1　34"))
-	assert.False(t, isViablePhoneNumber("1　3+4"))
+	assert.True(t, isViablePhoneNumber("1\u300034"))
+	assert.False(t, isViablePhoneNumber("1\u30003+4"))
 	// Unicode variants of possible starting character and other allowed punctuation/digits.
-	assert.True(t, isViablePhoneNumber("（1）　3456789"))
+	assert.True(t, isViablePhoneNumber("\uFF081\uFF09\u30003456789"))
 	// Testing a leading + is okay.
-	assert.True(t, isViablePhoneNumber("+1）　3456789"))
+	assert.True(t, isViablePhoneNumber("+1\uFF09\u30003456789"))
 }
 
 // testExtractPossibleNumber (PhoneNumberUtilTest.java:1825-1847)
@@ -83,9 +83,9 @@ func TestExtractPossibleNumber(t *testing.T) {
 	// Should not remove plus sign
 	assert.Equal(t, "+800-345-600", extractPossibleNumber("Tel:+800-345-600"))
 	// Should recognise wide digits as possible start values.
-	assert.Equal(t, "０２３", extractPossibleNumber("０２３"))
+	assert.Equal(t, "\uFF10\uFF12\uFF13", extractPossibleNumber("\uFF10\uFF12\uFF13"))
 	// Dashes are not possible start values and should be removed.
-	assert.Equal(t, "１２３", extractPossibleNumber("Num-１２３"))
+	assert.Equal(t, "\uFF11\uFF12\uFF13", extractPossibleNumber("Num-\uFF11\uFF12\uFF13"))
 	// If not possible number present, return empty string.
 	assert.Equal(t, "", extractPossibleNumber("Num-...."))
 	// Leading brackets are stripped - these are not used when parsing.
@@ -95,5 +95,5 @@ func TestExtractPossibleNumber(t *testing.T) {
 	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000..- .."))
 	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000."))
 	// This case has a trailing RTL char.
-	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000‏"))
+	assert.Equal(t, "650) 253-0000", extractPossibleNumber("(650) 253-0000\u200F"))
 }

--- a/phonenumberutil_parse_basic_test.go
+++ b/phonenumberutil_parse_basic_test.go
@@ -58,6 +58,116 @@ func TestMaybeStripNationalPrefixAndCarrierCode(t *testing.T) {
 	assert.Equal(t, "5315123", number.String())
 }
 
+// testMaybeStripInternationalPrefix (PhoneNumberUtilTest.java:1902-1960)
+func TestMaybeStripInternationalPrefix(t *testing.T) {
+	internationalPrefix := "00[39]"
+	numberToStrip := NewBuilder([]byte("0034567700-3898003"))
+	// Note the dash is removed as part of the normalization.
+	strippedNumber := "45677003898003"
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITH_IDD, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+	assert.Equal(t, strippedNumber, numberToStrip.String(), "The number supplied was not stripped of its international prefix.")
+	// Now the number no longer starts with an IDD prefix, so it should now report
+	// FROM_DEFAULT_COUNTRY.
+	assert.Equal(t, PhoneNumber_FROM_DEFAULT_COUNTRY, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+
+	numberToStrip = NewBuilder([]byte("00945677003898003"))
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITH_IDD, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+	assert.Equal(t, strippedNumber, numberToStrip.String(), "The number supplied was not stripped of its international prefix.")
+	// Test it works when the international prefix is broken up by spaces.
+	numberToStrip = NewBuilder([]byte("00 9 45677003898003"))
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITH_IDD, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+	assert.Equal(t, strippedNumber, numberToStrip.String(), "The number supplied was not stripped of its international prefix.")
+	// Now the number no longer starts with an IDD prefix, so it should now report
+	// FROM_DEFAULT_COUNTRY.
+	assert.Equal(t, PhoneNumber_FROM_DEFAULT_COUNTRY, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+
+	// Test the + symbol is also recognised and stripped.
+	numberToStrip = NewBuilder([]byte("+45677003898003"))
+	strippedNumber = "45677003898003"
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITH_PLUS_SIGN, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+	assert.Equal(t, strippedNumber, numberToStrip.String(), "The number supplied was not stripped of the plus symbol.")
+
+	// If the number afterwards is a zero, we should not strip this - no country calling code begins
+	// with 0.
+	numberToStrip = NewBuilder([]byte("0090112-3123"))
+	strippedNumber = "00901123123"
+	assert.Equal(t, PhoneNumber_FROM_DEFAULT_COUNTRY, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+	assert.Equal(t, strippedNumber, numberToStrip.String(), "The number supplied had a 0 after the match so shouldn't be stripped.")
+	// Here the 0 is separated by a space from the IDD.
+	numberToStrip = NewBuilder([]byte("009 0-112-3123"))
+	assert.Equal(t, PhoneNumber_FROM_DEFAULT_COUNTRY, maybeStripInternationalPrefixAndNormalize(numberToStrip, internationalPrefix))
+}
+
+// testMaybeExtractCountryCode (PhoneNumberUtilTest.java:1962-2090)
+func TestMaybeExtractCountryCode(t *testing.T) {
+	useTestMetadata(t)
+	metadata := getMetadataForRegion(regionCode.US)
+
+	// Note that for the US, the IDD is 011.
+	number := &PhoneNumber{}
+	numberToFill := NewBuilder(nil)
+	cc, err := maybeExtractCountryCode("011112-3456789", metadata, numberToFill, true, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cc, "Did not extract country calling code 1 correctly.")
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITH_IDD, number.GetCountryCodeSource(), "Did not figure out CountryCodeSource correctly")
+	// Should strip and normalize national significant number.
+	assert.Equal(t, "123456789", numberToFill.String(), "Did not strip off the country calling code correctly.")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	cc, err = maybeExtractCountryCode("+6423456789", metadata, numberToFill, true, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 64, cc, "Did not extract country calling code 64 correctly.")
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITH_PLUS_SIGN, number.GetCountryCodeSource(), "Did not figure out CountryCodeSource correctly")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	cc, err = maybeExtractCountryCode("+80012345678", metadata, numberToFill, true, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 800, cc, "Did not extract country calling code 800 correctly.")
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITH_PLUS_SIGN, number.GetCountryCodeSource(), "Did not figure out CountryCodeSource correctly")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	cc, err = maybeExtractCountryCode("2345-6789", metadata, numberToFill, true, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cc, "Should not have extracted a country calling code - no international prefix present.")
+	assert.Equal(t, PhoneNumber_FROM_DEFAULT_COUNTRY, number.GetCountryCodeSource(), "Did not figure out CountryCodeSource correctly")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	_, err = maybeExtractCountryCode("0119991123456789", metadata, numberToFill, true, number)
+	assert.ErrorIs(t, err, ErrInvalidCountryCode, "Should have thrown an exception, no valid country calling code present.")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	cc, err = maybeExtractCountryCode("(1 610) 619 4466", metadata, numberToFill, true, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cc, "Should have extracted the country calling code of the region passed in")
+	assert.Equal(t, PhoneNumber_FROM_NUMBER_WITHOUT_PLUS_SIGN, number.GetCountryCodeSource(), "Did not figure out CountryCodeSource correctly")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	cc, err = maybeExtractCountryCode("(1 610) 619 4466", metadata, numberToFill, false, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cc, "Should have extracted the country calling code of the region passed in")
+	assert.Nil(t, number.CountryCodeSource, "Should not contain CountryCodeSource.")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	cc, err = maybeExtractCountryCode("(1 610) 619 446", metadata, numberToFill, false, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cc, "Should not have extracted a country calling code - invalid number after extraction of uncertain country calling code.")
+	assert.Nil(t, number.CountryCodeSource, "Should not contain CountryCodeSource.")
+
+	number = &PhoneNumber{}
+	numberToFill = NewBuilder(nil)
+	cc, err = maybeExtractCountryCode("(1 610) 619", metadata, numberToFill, true, number)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cc, "Should not have extracted a country calling code - too short number both before and after extraction of uncertain country calling code.")
+	assert.Equal(t, PhoneNumber_FROM_DEFAULT_COUNTRY, number.GetCountryCodeSource(), "Did not figure out CountryCodeSource correctly")
+}
+
 func TestParseNationalNumber(t *testing.T) {
 	useTestMetadata(t)
 

--- a/phonenumberutil_parse_extensions_test.go
+++ b/phonenumberutil_parse_extensions_test.go
@@ -103,6 +103,7 @@ func TestParseExtensions(t *testing.T) {
 		{"+44 2034567890 X 456", regionCode.GB},
 		{"+44 2034567890 X  456", regionCode.GB},
 		{"+44 2034567890  X 456", regionCode.GB},
+		{"+44 2034567890 x 456  ", regionCode.GB},
 		{"+44-2034567890;ext=456", regionCode.GB},
 		{"tel:2034567890;ext=456;phone-context=+44", regionCode.ZZ},
 		// Full-width extension, "extn" only.
@@ -116,16 +117,6 @@ func TestParseExtensions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, proto.Equal(ukNumber, got), "input %q", tc.in)
 	}
-
-	// DIVERGENCE(upstream): upstream parses "+44 2034567890 x 456  " (trailing
-	// whitespace after the extension digits) as ukNumber with extension "456",
-	// but the Go extension regex does not tolerate trailing whitespace, so the
-	// "456" is folded into the national number (2034567890456) and no extension
-	// is extracted. We assert our actual behavior here. TODO reconcile.
-	got2, err2 := Parse("+44 2034567890 x 456  ", regionCode.GB)
-	assert.NoError(t, err2)
-	assert.Equal(t, uint64(2034567890456), got2.GetNationalNumber())
-	assert.Equal(t, "", got2.GetExtension())
 
 	usWithExtension := pn(1, 8009013355)
 	usWithExtension.Extension = proto.String("7246433")

--- a/phonenumberutil_possibility_test.go
+++ b/phonenumberutil_possibility_test.go
@@ -1,0 +1,133 @@
+package phonenumbers
+
+// Faithful port of upstream libphonenumber's PhoneNumberUtilTest.java
+// possibility / truncation methods, run against the synthetic test metadata.
+// Method names and assertions mirror the Java. Last reconciled against: v9.0.32
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+// possibleWithRegion is the test-local stand-in for upstream's
+// isPossibleNumber(CharSequence, regionDialingFrom) overload, which the Go API
+// does not expose (only the *PhoneNumber form). It parses then checks
+// possibility, returning false if parsing fails — mirroring upstream's catch of
+// NumberParseException.
+func possibleWithRegion(number, regionDialingFrom string) bool {
+	num, err := Parse(number, regionDialingFrom)
+	if err != nil {
+		return false
+	}
+	return IsPossibleNumber(num)
+}
+
+// testIsPossibleNumber (PhoneNumberUtilTest.java:1375-1391)
+func TestIsPossibleNumber(t *testing.T) {
+	useTestMetadata(t)
+	assert.True(t, IsPossibleNumber(usNumber()))
+	assert.True(t, IsPossibleNumber(usLocalNumber()))
+	assert.True(t, IsPossibleNumber(gbNumber()))
+	assert.True(t, IsPossibleNumber(internationalTollFree()))
+
+	assert.True(t, possibleWithRegion("+1 650 253 0000", regionCode.US))
+	assert.True(t, possibleWithRegion("+1 650 GOO OGLE", regionCode.US))
+	assert.True(t, possibleWithRegion("(650) 253-0000", regionCode.US))
+	assert.True(t, possibleWithRegion("253-0000", regionCode.US))
+	assert.True(t, possibleWithRegion("+1 650 253 0000", regionCode.GB))
+	assert.True(t, possibleWithRegion("+44 20 7031 3000", regionCode.GB))
+	assert.True(t, possibleWithRegion("(020) 7031 300", regionCode.GB))
+	assert.True(t, possibleWithRegion("7031 3000", regionCode.GB))
+	assert.True(t, possibleWithRegion("3331 6005", regionCode.NZ))
+	assert.True(t, possibleWithRegion("+800 1234 5678", regionCode.UN001))
+}
+
+// testIsPossibleNumberWithReason (PhoneNumberUtilTest.java:1475-1500)
+func TestIsPossibleNumberWithReason(t *testing.T) {
+	useTestMetadata(t)
+	// National numbers for country calling code +1 that are within 7 to 10 digits are possible.
+	assert.Equal(t, IS_POSSIBLE, IsPossibleNumberWithReason(usNumber()))
+
+	assert.Equal(t, IS_POSSIBLE_LOCAL_ONLY, IsPossibleNumberWithReason(usLocalNumber()))
+
+	assert.Equal(t, TOO_LONG, IsPossibleNumberWithReason(usLongNumber()))
+
+	number := &PhoneNumber{CountryCode: proto.Int32(0), NationalNumber: proto.Uint64(2530000)}
+	assert.Equal(t, INVALID_COUNTRY_CODE, IsPossibleNumberWithReason(number))
+
+	number = &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(253000)}
+	assert.Equal(t, TOO_SHORT, IsPossibleNumberWithReason(number))
+
+	number = &PhoneNumber{CountryCode: proto.Int32(65), NationalNumber: proto.Uint64(1234567890)}
+	assert.Equal(t, IS_POSSIBLE, IsPossibleNumberWithReason(number))
+
+	assert.Equal(t, TOO_LONG, IsPossibleNumberWithReason(internationalTollFreeTooLong()))
+}
+
+// testIsNotPossibleNumber (PhoneNumberUtilTest.java:1727-1745)
+func TestIsNotPossibleNumber(t *testing.T) {
+	useTestMetadata(t)
+	assert.False(t, IsPossibleNumber(usLongNumber()))
+	assert.False(t, IsPossibleNumber(internationalTollFreeTooLong()))
+
+	number := &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(253000)}
+	assert.False(t, IsPossibleNumber(number))
+
+	number = &PhoneNumber{CountryCode: proto.Int32(44), NationalNumber: proto.Uint64(300)}
+	assert.False(t, IsPossibleNumber(number))
+	assert.False(t, possibleWithRegion("+1 650 253 00000", regionCode.US))
+	assert.False(t, possibleWithRegion("(650) 253-00000", regionCode.US))
+	assert.False(t, possibleWithRegion("I want a Pizza", regionCode.US))
+	assert.False(t, possibleWithRegion("253-000", regionCode.US))
+	assert.False(t, possibleWithRegion("1 3000", regionCode.GB))
+	assert.False(t, possibleWithRegion("+44 300", regionCode.GB))
+	assert.False(t, possibleWithRegion("+800 1234 5678 9", regionCode.UN001))
+}
+
+// testTruncateTooLongNumber (PhoneNumberUtilTest.java:1747-1796)
+func TestTruncateTooLongNumber(t *testing.T) {
+	useTestMetadata(t)
+	// GB number 080 1234 5678, but entered with 4 extra digits at the end.
+	tooLongNumber := &PhoneNumber{CountryCode: proto.Int32(44), NationalNumber: proto.Uint64(80123456780123)}
+	validNumber := &PhoneNumber{CountryCode: proto.Int32(44), NationalNumber: proto.Uint64(8012345678)}
+	assert.True(t, TruncateTooLongNumber(tooLongNumber))
+	assert.True(t, proto.Equal(validNumber, tooLongNumber))
+
+	// IT number 022 3456 7890, but entered with 3 extra digits at the end.
+	tooLongNumber = &PhoneNumber{CountryCode: proto.Int32(39), NationalNumber: proto.Uint64(2234567890123), ItalianLeadingZero: proto.Bool(true)}
+	validNumber = &PhoneNumber{CountryCode: proto.Int32(39), NationalNumber: proto.Uint64(2234567890), ItalianLeadingZero: proto.Bool(true)}
+	assert.True(t, TruncateTooLongNumber(tooLongNumber))
+	assert.True(t, proto.Equal(validNumber, tooLongNumber))
+
+	// US number 650-253-0000, but entered with one additional digit at the end.
+	tooLongNumber = usLongNumber()
+	assert.True(t, TruncateTooLongNumber(tooLongNumber))
+	assert.True(t, proto.Equal(usNumber(), tooLongNumber))
+
+	tooLongNumber = internationalTollFreeTooLong()
+	assert.True(t, TruncateTooLongNumber(tooLongNumber))
+	assert.True(t, proto.Equal(internationalTollFree(), tooLongNumber))
+
+	// Tests what happens when a valid number is passed in.
+	validNumberCopy := proto.Clone(validNumber).(*PhoneNumber)
+	assert.True(t, TruncateTooLongNumber(validNumber))
+	// Tests the number is not modified.
+	assert.True(t, proto.Equal(validNumberCopy, validNumber))
+
+	// Tests what happens when a number with invalid prefix is passed in.
+	// The test metadata says US numbers cannot have prefix 240.
+	numberWithInvalidPrefix := &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(2401234567)}
+	invalidNumberCopy := proto.Clone(numberWithInvalidPrefix).(*PhoneNumber)
+	assert.False(t, TruncateTooLongNumber(numberWithInvalidPrefix))
+	// Tests the number is not modified.
+	assert.True(t, proto.Equal(invalidNumberCopy, numberWithInvalidPrefix))
+
+	// Tests what happens when a too short number is passed in.
+	tooShortNumber := &PhoneNumber{CountryCode: proto.Int32(1), NationalNumber: proto.Uint64(1234)}
+	tooShortNumberCopy := proto.Clone(tooShortNumber).(*PhoneNumber)
+	assert.False(t, TruncateTooLongNumber(tooShortNumber))
+	// Tests the number is not modified.
+	assert.True(t, proto.Equal(tooShortNumberCopy, tooShortNumber))
+}


### PR DESCRIPTION
## What

Faithfully ports the last batch of `PhoneNumberUtilTest` methods that were only covered by ad-hoc real-metadata tests (or not at all), and deletes the superseded ad-hoc tests. **After this, `PhoneNumberUtilTest` is fully ported except the two Mockito missing-metadata tests.**

New / extended test files:
- **`phonenumberutil_normalize_test.go`** (new): `testConvertAlphaCharactersInNumber`, the `testNormalise*` family (5), `testIsViablePhoneNumber` (+`NonAscii`), `testExtractPossibleNumber`. These exercise static helpers, so they don't use `useTestMetadata`; non-ASCII inputs mirror upstream's `\u` escapes.
- **`phonenumberutil_possibility_test.go`** (new): `testIsPossibleNumber`, `testIsPossibleNumberWithReason`, `testIsNotPossibleNumber`, `testTruncateTooLongNumber`.
- **`phonenumberutil_parse_basic_test.go`**: adds `testMaybeStripInternationalPrefix` and `testMaybeExtractCountryCode` (parsing internals, placed beside the already-ported `maybeStripNationalPrefix`, in upstream order).

Removed 8 superseded ad-hoc tests (`TestConvertAlphaCharactersInNumber`, `TestExtractPossibleNumber`, `TestIsViablePhoneNumber`, `TestNormalize`, `TestNormalizeDigitsOnly`, `TestNormalizeDiallableCharsOnly`, `TestIsPossibleNumberWithReason`, `TestTruncateTooLongNumber`).

## ⚠️ Bug the port surfaced (fixed)

`extractPossibleNumber` never trimmed trailing junk. `UNWANTED_END_CHARS` was copied verbatim from Java — `[[\P{N}&&\P{L}]&&[^#]]+$` — but Go's RE2 engine has **no character-class intersection (`&&`)**, so the pattern compiled to something meaningless and matched nothing. Rewrote it as the equivalent RE2 negated class `[^\p{N}\p{L}#]+$` (verified across the upstream cases).

A nice side effect: this **resolved the documented trailing-whitespace divergence** in `testParseExtensions` — `"+44 2034567890 x 456  "` now extracts extension `456` exactly like upstream (line 2640) instead of folding the digits into the national number. That case is folded back into the faithful `ukNumber` group and the divergence block + the PORT_STATUS TODO are removed.

## Notes for reviewers

- `phonenumberutil.go` has exactly one production change (the regex). It's the only `&&`-intersection regex in the file (checked).
- Go has no string+region `isPossibleNumber` overload, so the string-form assertions in `testIsPossibleNumber`/`testIsNotPossibleNumber` use a documented test-local helper `possibleWithRegion` (parse + `IsPossibleNumber`, false on parse error — mirroring upstream's `catch`), the same precedent as `exampleNumberForTypeAnyRegion`.
- The two complex parsing-internals ports (`maybeStripInternationalPrefix`, `maybeExtractCountryCode`) passed as-is — no further bugs there.
- `docs/PORT_STATUS.md` updated: PhoneNumberUtilTest marked ported-except-Mockito, the regex bug recorded, and the resolved divergence removed.

## Verification

`gofmt -l`, `go vet ./...`, `go build ./...`, `go test ./...`, and `go test -race ./...` all clean.