### PR TITLE
Port AsYouTypeFormatter and AsYouTypeFormatterTest

### DIFF
--- a/asyoutypeformatter.go
+++ b/asyoutypeformatter.go
@@ -1,0 +1,676 @@
+package phonenumbers
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// AsYouTypeFormatter formats phone numbers as they are entered. It is a port of
+// libphonenumber's AsYouTypeFormatter (Java reference implementation).
+//
+// An AsYouTypeFormatter is obtained from GetAsYouTypeFormatter. After that,
+// digits can be added by calling InputDigit on the instance, and the partially
+// formatted phone number is returned each time a digit is added. Clear can be
+// called before formatting a new number.
+//
+// See AsYouTypeFormatter's tests for more details on how the formatter is to be
+// used.
+type AsYouTypeFormatter struct {
+	currentOutput string
+	// formattingTemplate holds the current template with not-yet-entered digits
+	// represented by the DIGIT_PLACEHOLDER rune. It is kept as a []rune (rather
+	// than a StringBuilder) because the placeholder is a multi-byte rune and the
+	// template is manipulated by character index, where rune indices match Java's
+	// UTF-16 char indices for every (BMP) character a phone number can contain.
+	formattingTemplate []rune
+	// currentFormattingPattern is the pattern from the NumberFormat currently used
+	// to create formattingTemplate.
+	currentFormattingPattern      string
+	accruedInput                  *StringBuilder
+	accruedInputWithoutFormatting *StringBuilder
+	// ableToFormat indicates whether the formatter is currently doing formatting.
+	ableToFormat bool
+	// inputHasFormatting is set to true when users enter their own formatting. The
+	// formatter will do no formatting at all when this is true.
+	inputHasFormatting bool
+	// isCompleteNumber is set to true when we know the user is entering a full
+	// national significant number, since we have either detected a national prefix
+	// or an international dialing prefix. When this is true, we will no longer use
+	// local number formatting patterns.
+	isCompleteNumber              bool
+	isExpectingCountryCallingCode bool
+	defaultCountry                string
+
+	defaultMetadata *PhoneMetadata
+	currentMetadata *PhoneMetadata
+
+	lastMatchPosition int
+	// originalPosition is the position of a digit upon which
+	// InputDigitAndRememberPosition was most recently invoked, as found in the
+	// original sequence of characters the user entered.
+	originalPosition int
+	// positionToRemember is the position of a digit upon which
+	// InputDigitAndRememberPosition was most recently invoked, as found in
+	// accruedInputWithoutFormatting.
+	positionToRemember int
+	// prefixBeforeNationalNumber contains anything that has been entered so far
+	// preceding the national significant number, and it is formatted (e.g. with
+	// space inserted). For example, this can contain IDD, country code, and/or
+	// NDD, etc.
+	prefixBeforeNationalNumber        *StringBuilder
+	shouldAddSpaceAfterNationalPrefix bool
+	// extractedNationalPrefix contains the national prefix that has been extracted.
+	// It contains only digits without formatting.
+	extractedNationalPrefix string
+	nationalNumber          *StringBuilder
+	possibleFormats         []*NumberFormat
+}
+
+// SEPARATOR_BEFORE_NATIONAL_NUMBER is the character used when appropriate to
+// separate a prefix, such as a long NDD or a country calling code, from the
+// national number.
+const SEPARATOR_BEFORE_NATIONAL_NUMBER = ' '
+
+// MIN_LEADING_DIGITS_LENGTH is the minimum length of national number accrued
+// that is required to trigger the formatter. The first element of the
+// leadingDigitsPattern of each numberFormat contains a regular expression that
+// matches up to this number of digits.
+const MIN_LEADING_DIGITS_LENGTH = 3
+
+// DIGIT_PLACEHOLDER represents the digits that have not been entered yet, using
+//  , the punctuation space.
+const DIGIT_PLACEHOLDER = " "
+
+const digitPlaceholderRune = ' '
+
+var (
+	// EMPTY_METADATA is used as a default instance of metadata. It allows the
+	// formatter to function with an incorrect region code, even if formatting only
+	// works for numbers specified with "+".
+	EMPTY_METADATA = &PhoneMetadata{
+		Id:                  proto.String("<ignored>"),
+		InternationalPrefix: proto.String("NA"),
+	}
+
+	// ELIGIBLE_FORMAT_PATTERN determines if a numberFormat under availableFormats is
+	// eligible to be used by the formatter. It is eligible when the format element
+	// under numberFormat contains groups of the dollar sign followed by a single
+	// digit, separated by valid phone number punctuation. This prevents invalid
+	// punctuation (such as the star sign in Israeli star numbers) getting into the
+	// output of the formatter. We require that the first group is present in the
+	// output pattern to ensure no data is lost while formatting; when we format as
+	// you type, this should always be the case. Anchored to require a full match,
+	// mirroring Java's Matcher.matches().
+	ELIGIBLE_FORMAT_PATTERN = regexp.MustCompile("^(?:[" + VALID_PUNCTUATION + "]*" +
+		"\\$1" + "[" + VALID_PUNCTUATION + "]*(?:\\$\\d" + "[" + VALID_PUNCTUATION + "]*)*)$")
+
+	// NATIONAL_PREFIX_SEPARATORS_PATTERN is a set of characters that, if found in a
+	// national prefix formatting rule, are an indicator to us that we should
+	// separate the national prefix from the number when formatting.
+	NATIONAL_PREFIX_SEPARATORS_PATTERN = regexp.MustCompile("[- ]")
+)
+
+// GetAsYouTypeFormatter returns an AsYouTypeFormatter for the specific region.
+func GetAsYouTypeFormatter(regionCode string) *AsYouTypeFormatter {
+	return newAsYouTypeFormatter(regionCode)
+}
+
+// newAsYouTypeFormatter constructs an as-you-type formatter for the given region.
+func newAsYouTypeFormatter(regionCode string) *AsYouTypeFormatter {
+	aytf := &AsYouTypeFormatter{
+		ableToFormat:                  true,
+		defaultCountry:                regionCode,
+		accruedInput:                  NewStringBuilder(nil),
+		accruedInputWithoutFormatting: NewStringBuilder(nil),
+		prefixBeforeNationalNumber:    NewStringBuilder(nil),
+		nationalNumber:                NewStringBuilder(nil),
+	}
+	aytf.currentMetadata = aytf.getMetadataForRegion(regionCode)
+	aytf.defaultMetadata = aytf.currentMetadata
+	return aytf
+}
+
+// getMetadataForRegion returns the metadata needed by this formatter. It is the
+// same for all regions sharing the same country calling code, so we return the
+// metadata for the "main" region for this country calling code.
+func (aytf *AsYouTypeFormatter) getMetadataForRegion(regionCode string) *PhoneMetadata {
+	countryCallingCode := GetCountryCodeForRegion(regionCode)
+	mainCountry := GetRegionCodeForCountryCode(countryCallingCode)
+	metadata := getMetadataForRegion(mainCountry)
+	if metadata != nil {
+		return metadata
+	}
+	return EMPTY_METADATA
+}
+
+// maybeCreateNewTemplate returns true if a new template is created as opposed to
+// reusing the existing template.
+func (aytf *AsYouTypeFormatter) maybeCreateNewTemplate() bool {
+	// When there are multiple available formats, the formatter uses the first format
+	// where a formatting template could be created.
+	i := 0
+	for i < len(aytf.possibleFormats) {
+		numberFormat := aytf.possibleFormats[i]
+		pattern := numberFormat.GetPattern()
+		if aytf.currentFormattingPattern == pattern {
+			return false
+		}
+		if aytf.createFormattingTemplate(numberFormat) {
+			aytf.currentFormattingPattern = pattern
+			aytf.shouldAddSpaceAfterNationalPrefix =
+				NATIONAL_PREFIX_SEPARATORS_PATTERN.MatchString(numberFormat.GetNationalPrefixFormattingRule())
+			// With a new formatting template, the matched position using the old template
+			// needs to be reset.
+			aytf.lastMatchPosition = 0
+			return true
+		}
+		// Remove the current number format from possibleFormats.
+		aytf.possibleFormats = append(aytf.possibleFormats[:i], aytf.possibleFormats[i+1:]...)
+	}
+	aytf.ableToFormat = false
+	return false
+}
+
+func (aytf *AsYouTypeFormatter) getAvailableFormats(leadingDigits string) {
+	// First decide whether we should use international or national number rules.
+	isInternationalNumber := aytf.isCompleteNumber && len(aytf.extractedNationalPrefix) == 0
+	var formatList []*NumberFormat
+	if isInternationalNumber && len(aytf.currentMetadata.GetIntlNumberFormat()) > 0 {
+		formatList = aytf.currentMetadata.GetIntlNumberFormat()
+	} else {
+		formatList = aytf.currentMetadata.GetNumberFormat()
+	}
+	for _, format := range formatList {
+		// Discard a few formats that we know are not relevant based on the presence of
+		// the national prefix.
+		if len(aytf.extractedNationalPrefix) > 0 &&
+			formattingRuleHasFirstGroupOnly(format.GetNationalPrefixFormattingRule()) &&
+			!format.GetNationalPrefixOptionalWhenFormatting() &&
+			len(format.GetDomesticCarrierCodeFormattingRule()) == 0 {
+			// If it is a national number that had a national prefix, any rules that aren't
+			// valid with a national prefix should be excluded. A rule that has a carrier-code
+			// formatting rule is kept since the national prefix might actually be an extracted
+			// carrier code - we don't distinguish between these when extracting it in the AYTF.
+			continue
+		} else if len(aytf.extractedNationalPrefix) == 0 &&
+			!aytf.isCompleteNumber &&
+			!formattingRuleHasFirstGroupOnly(format.GetNationalPrefixFormattingRule()) &&
+			!format.GetNationalPrefixOptionalWhenFormatting() {
+			// This number was entered without a national prefix, and this formatting rule
+			// requires one, so we discard it.
+			continue
+		}
+		if ELIGIBLE_FORMAT_PATTERN.MatchString(format.GetFormat()) {
+			aytf.possibleFormats = append(aytf.possibleFormats, format)
+		}
+	}
+	aytf.narrowDownPossibleFormats(leadingDigits)
+}
+
+func (aytf *AsYouTypeFormatter) narrowDownPossibleFormats(leadingDigits string) {
+	indexOfLeadingDigitsPattern := len(leadingDigits) - MIN_LEADING_DIGITS_LENGTH
+	i := 0
+	for i < len(aytf.possibleFormats) {
+		format := aytf.possibleFormats[i]
+		if len(format.GetLeadingDigitsPattern()) == 0 {
+			// Keep everything that isn't restricted by leading digits.
+			i++
+			continue
+		}
+		lastLeadingDigitsPattern := indexOfLeadingDigitsPattern
+		if count := len(format.GetLeadingDigitsPattern()) - 1; count < lastLeadingDigitsPattern {
+			lastLeadingDigitsPattern = count
+		}
+		leadingDigitsPattern := regexFor("^(?:" + format.GetLeadingDigitsPattern()[lastLeadingDigitsPattern] + ")")
+		if !leadingDigitsPattern.MatchString(leadingDigits) {
+			aytf.possibleFormats = append(aytf.possibleFormats[:i], aytf.possibleFormats[i+1:]...)
+		} else {
+			i++
+		}
+	}
+}
+
+func (aytf *AsYouTypeFormatter) createFormattingTemplate(format *NumberFormat) bool {
+	numberPattern := format.GetPattern()
+	aytf.formattingTemplate = aytf.formattingTemplate[:0]
+	tempTemplate := aytf.getFormattingTemplate(numberPattern, format.GetFormat())
+	if len(tempTemplate) > 0 {
+		aytf.formattingTemplate = append(aytf.formattingTemplate, []rune(tempTemplate)...)
+		return true
+	}
+	return false
+}
+
+// getFormattingTemplate gets a formatting template which can be used to
+// efficiently format a partial number where digits are added one by one.
+func (aytf *AsYouTypeFormatter) getFormattingTemplate(numberPattern, numberFormat string) string {
+	// Creates a phone number consisting only of the digit 9 that matches the
+	// numberPattern by applying the pattern to the longestPhoneNumber string.
+	longestPhoneNumber := "999999999999999"
+	m := regexFor(numberPattern)
+	aPhoneNumber := m.FindString(longestPhoneNumber) // this will always succeed
+	// No formatting template can be created if the number of digits entered so far is
+	// longer than the maximum the current formatting rule can accommodate.
+	if len(aPhoneNumber) < aytf.nationalNumber.Len() {
+		return ""
+	}
+	// Formats the number according to numberFormat.
+	template := m.ReplaceAllString(aPhoneNumber, numberFormat)
+	// Replaces each digit with character DIGIT_PLACEHOLDER.
+	template = strings.ReplaceAll(template, "9", DIGIT_PLACEHOLDER)
+	return template
+}
+
+// Clear clears the internal state of the formatter, so it can be reused.
+func (aytf *AsYouTypeFormatter) Clear() {
+	aytf.currentOutput = ""
+	aytf.accruedInput.Reset()
+	aytf.accruedInputWithoutFormatting.Reset()
+	aytf.formattingTemplate = aytf.formattingTemplate[:0]
+	aytf.lastMatchPosition = 0
+	aytf.currentFormattingPattern = ""
+	aytf.prefixBeforeNationalNumber.Reset()
+	aytf.extractedNationalPrefix = ""
+	aytf.nationalNumber.Reset()
+	aytf.ableToFormat = true
+	aytf.inputHasFormatting = false
+	aytf.positionToRemember = 0
+	aytf.originalPosition = 0
+	aytf.isCompleteNumber = false
+	aytf.isExpectingCountryCallingCode = false
+	aytf.possibleFormats = aytf.possibleFormats[:0]
+	aytf.shouldAddSpaceAfterNationalPrefix = false
+	if aytf.currentMetadata != aytf.defaultMetadata {
+		aytf.currentMetadata = aytf.getMetadataForRegion(aytf.defaultCountry)
+	}
+}
+
+// InputDigit formats a phone number on-the-fly as each digit is entered.
+//
+// nextChar is the most recently entered digit of a phone number. Formatting
+// characters are allowed, but as soon as they are encountered this method formats
+// the number as entered and not "as you type" anymore. Full width digits and
+// Arabic-indic digits are allowed, and will be shown as they are. It returns the
+// partially formatted phone number.
+func (aytf *AsYouTypeFormatter) InputDigit(nextChar rune) string {
+	aytf.currentOutput = aytf.inputDigitWithOptionToRememberPosition(nextChar, false)
+	return aytf.currentOutput
+}
+
+// InputDigitAndRememberPosition is the same as InputDigit, but remembers the
+// position where nextChar is inserted, so that it can be retrieved later using
+// GetRememberedPosition. The remembered position will be automatically adjusted
+// if additional formatting characters are later inserted/removed in front of
+// nextChar.
+func (aytf *AsYouTypeFormatter) InputDigitAndRememberPosition(nextChar rune) string {
+	aytf.currentOutput = aytf.inputDigitWithOptionToRememberPosition(nextChar, true)
+	return aytf.currentOutput
+}
+
+func (aytf *AsYouTypeFormatter) inputDigitWithOptionToRememberPosition(nextChar rune, rememberPosition bool) string {
+	aytf.accruedInput.WriteRune(nextChar)
+	if rememberPosition {
+		aytf.originalPosition = utf8.RuneCount(aytf.accruedInput.Bytes())
+	}
+	// We do formatting on-the-fly only when each character entered is either a digit,
+	// or a plus sign (accepted at the start of the number only).
+	if !aytf.isDigitOrLeadingPlusSign(nextChar) {
+		aytf.ableToFormat = false
+		aytf.inputHasFormatting = true
+	} else {
+		nextChar = aytf.normalizeAndAccrueDigitsAndPlusSign(nextChar, rememberPosition)
+	}
+	if !aytf.ableToFormat {
+		// When we are unable to format because of reasons other than that formatting chars
+		// have been entered, it can be due to really long IDDs or NDDs. If that is the case,
+		// we might be able to do formatting again after extracting them.
+		if aytf.inputHasFormatting {
+			return aytf.accruedInput.String()
+		} else if aytf.attemptToExtractIdd() {
+			if aytf.attemptToExtractCountryCallingCode() {
+				return aytf.attemptToChoosePatternWithPrefixExtracted()
+			}
+		} else if aytf.ableToExtractLongerNdd() {
+			// Add an additional space to separate long NDD and national significant number for
+			// readability. We don't set shouldAddSpaceAfterNationalPrefix to true, since we don't
+			// want this to change later when we choose formatting templates.
+			aytf.prefixBeforeNationalNumber.WriteByte(byte(SEPARATOR_BEFORE_NATIONAL_NUMBER))
+			return aytf.attemptToChoosePatternWithPrefixExtracted()
+		}
+		return aytf.accruedInput.String()
+	}
+
+	// We start to attempt to format only when at least MIN_LEADING_DIGITS_LENGTH
+	// digits (the plus sign is counted as a digit as well for this purpose) have been
+	// entered.
+	switch aytf.accruedInputWithoutFormatting.Len() {
+	case 0, 1, 2:
+		return aytf.accruedInput.String()
+	case 3:
+		if aytf.attemptToExtractIdd() {
+			aytf.isExpectingCountryCallingCode = true
+		} else { // No IDD or plus sign is found, might be entering in national format.
+			aytf.extractedNationalPrefix = aytf.removeNationalPrefixFromNationalNumber()
+			return aytf.attemptToChooseFormattingPattern()
+		}
+		fallthrough
+	default:
+		if aytf.isExpectingCountryCallingCode {
+			if aytf.attemptToExtractCountryCallingCode() {
+				aytf.isExpectingCountryCallingCode = false
+			}
+			return aytf.prefixBeforeNationalNumber.String() + aytf.nationalNumber.String()
+		}
+		if len(aytf.possibleFormats) > 0 { // The formatting patterns are already chosen.
+			tempNationalNumber := aytf.inputDigitHelper(nextChar)
+			// See if the accrued digits can be formatted properly already. If not, use the
+			// results from inputDigitHelper, which does formatting based on the formatting
+			// pattern chosen.
+			formattedNumber := aytf.attemptToFormatAccruedDigits()
+			if len(formattedNumber) > 0 {
+				return formattedNumber
+			}
+			aytf.narrowDownPossibleFormats(aytf.nationalNumber.String())
+			if aytf.maybeCreateNewTemplate() {
+				return aytf.inputAccruedNationalNumber()
+			}
+			if aytf.ableToFormat {
+				return aytf.appendNationalNumber(tempNationalNumber)
+			}
+			return aytf.accruedInput.String()
+		}
+		return aytf.attemptToChooseFormattingPattern()
+	}
+}
+
+func (aytf *AsYouTypeFormatter) attemptToChoosePatternWithPrefixExtracted() string {
+	aytf.ableToFormat = true
+	aytf.isExpectingCountryCallingCode = false
+	aytf.possibleFormats = aytf.possibleFormats[:0]
+	aytf.lastMatchPosition = 0
+	aytf.formattingTemplate = aytf.formattingTemplate[:0]
+	aytf.currentFormattingPattern = ""
+	return aytf.attemptToChooseFormattingPattern()
+}
+
+// getExtractedNationalPrefix is visible for testing.
+func (aytf *AsYouTypeFormatter) getExtractedNationalPrefix() string {
+	return aytf.extractedNationalPrefix
+}
+
+// ableToExtractLongerNdd handles the case where some national prefixes are a
+// substring of others. If extracting the shorter NDD doesn't result in a number
+// we can format, we try to see if we can extract a longer version here.
+func (aytf *AsYouTypeFormatter) ableToExtractLongerNdd() bool {
+	if len(aytf.extractedNationalPrefix) > 0 {
+		// Put the extracted NDD back to the national number before attempting to extract a
+		// new NDD.
+		aytf.nationalNumber.InsertString(0, aytf.extractedNationalPrefix)
+		// Remove the previously extracted NDD from prefixBeforeNationalNumber. We cannot
+		// simply set it to empty string because people sometimes incorrectly enter national
+		// prefix after the country code, e.g. +44 (0)20-1234-5678.
+		indexOfPreviousNdd := aytf.prefixBeforeNationalNumber.lastIndexOf(aytf.extractedNationalPrefix)
+		aytf.prefixBeforeNationalNumber.setLength(indexOfPreviousNdd)
+	}
+	return aytf.extractedNationalPrefix != aytf.removeNationalPrefixFromNationalNumber()
+}
+
+func (aytf *AsYouTypeFormatter) isDigitOrLeadingPlusSign(nextChar rune) bool {
+	return unicode.IsDigit(nextChar) ||
+		(utf8.RuneCount(aytf.accruedInput.Bytes()) == 1 &&
+			PLUS_CHARS_PATTERN.MatchString(string(nextChar)))
+}
+
+// attemptToFormatAccruedDigits checks to see if there is an exact pattern match
+// for these digits. If so, we should use this instead of any other formatting
+// template whose leadingDigitsPattern also matches the input.
+func (aytf *AsYouTypeFormatter) attemptToFormatAccruedDigits() string {
+	for _, numberFormat := range aytf.possibleFormats {
+		m := regexFor("^(?:" + numberFormat.GetPattern() + ")$")
+		if m.MatchString(aytf.nationalNumber.String()) {
+			aytf.shouldAddSpaceAfterNationalPrefix =
+				NATIONAL_PREFIX_SEPARATORS_PATTERN.MatchString(numberFormat.GetNationalPrefixFormattingRule())
+			formattedNumber := m.ReplaceAllString(aytf.nationalNumber.String(), numberFormat.GetFormat())
+			// Check that we did not remove nor add any extra digits when we matched this
+			// formatting pattern. This usually happens after we entered the last digit during
+			// AYTF. Eg: In case of MX, we swallow mobile token (1) when formatted but AYTF should
+			// retain all the number entered and not change in order to match a format (of same
+			// leading digits and length) display in that way.
+			fullOutput := aytf.appendNationalNumber(formattedNumber)
+			formattedNumberDigitsOnly := normalizeDiallableCharsOnly(fullOutput)
+			if formattedNumberDigitsOnly == aytf.accruedInputWithoutFormatting.String() {
+				// If it's the same (i.e entered number and format is same), then it's safe to
+				// return this in formatted number as nothing is lost / added.
+				return fullOutput
+			}
+		}
+	}
+	return ""
+}
+
+// GetRememberedPosition returns the current position in the partially formatted
+// phone number of the character which was previously passed in as the parameter
+// of InputDigitAndRememberPosition.
+func (aytf *AsYouTypeFormatter) GetRememberedPosition() int {
+	if !aytf.ableToFormat {
+		return aytf.originalPosition
+	}
+	// Positions are tracked as rune counts, which match Java's UTF-16 char positions
+	// for every (BMP) character a phone number can contain.
+	accruedInputRunes := []rune(aytf.accruedInputWithoutFormatting.String())
+	currentOutputRunes := []rune(aytf.currentOutput)
+	accruedInputIndex := 0
+	currentOutputIndex := 0
+	for accruedInputIndex < aytf.positionToRemember && currentOutputIndex < len(currentOutputRunes) {
+		if accruedInputRunes[accruedInputIndex] == currentOutputRunes[currentOutputIndex] {
+			accruedInputIndex++
+		}
+		currentOutputIndex++
+	}
+	return currentOutputIndex
+}
+
+// appendNationalNumber combines the national number with any prefix (IDD/+ and
+// country code or national prefix) that was collected. A space will be inserted
+// between them if the current formatting template indicates this to be suitable.
+func (aytf *AsYouTypeFormatter) appendNationalNumber(nationalNumber string) string {
+	prefixBeforeNationalNumberLength := aytf.prefixBeforeNationalNumber.Len()
+	if aytf.shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumberLength > 0 &&
+		aytf.prefixBeforeNationalNumber.charAt(prefixBeforeNationalNumberLength-1) != byte(SEPARATOR_BEFORE_NATIONAL_NUMBER) {
+		// We want to add a space after the national prefix if the national prefix formatting
+		// rule indicates that this would normally be done, with the exception of the case
+		// where we already appended a space because the NDD was surprisingly long.
+		return aytf.prefixBeforeNationalNumber.String() + string(SEPARATOR_BEFORE_NATIONAL_NUMBER) + nationalNumber
+	}
+	return aytf.prefixBeforeNationalNumber.String() + nationalNumber
+}
+
+// attemptToChooseFormattingPattern attempts to set the formatting template and
+// returns a string which contains the formatted version of the digits entered so
+// far.
+func (aytf *AsYouTypeFormatter) attemptToChooseFormattingPattern() string {
+	// We start to attempt to format only when at least MIN_LEADING_DIGITS_LENGTH
+	// digits of national number (excluding national prefix) have been entered.
+	if aytf.nationalNumber.Len() >= MIN_LEADING_DIGITS_LENGTH {
+		aytf.getAvailableFormats(aytf.nationalNumber.String())
+		// See if the accrued digits can be formatted properly already.
+		formattedNumber := aytf.attemptToFormatAccruedDigits()
+		if len(formattedNumber) > 0 {
+			return formattedNumber
+		}
+		if aytf.maybeCreateNewTemplate() {
+			return aytf.inputAccruedNationalNumber()
+		}
+		return aytf.accruedInput.String()
+	}
+	return aytf.appendNationalNumber(aytf.nationalNumber.String())
+}
+
+// inputAccruedNationalNumber invokes inputDigitHelper on each digit of the
+// national number accrued, and returns a formatted string in the end.
+func (aytf *AsYouTypeFormatter) inputAccruedNationalNumber() string {
+	lengthOfNationalNumber := aytf.nationalNumber.Len()
+	if lengthOfNationalNumber > 0 {
+		tempNationalNumber := ""
+		for i := 0; i < lengthOfNationalNumber; i++ {
+			tempNationalNumber = aytf.inputDigitHelper(rune(aytf.nationalNumber.charAt(i)))
+		}
+		if aytf.ableToFormat {
+			return aytf.appendNationalNumber(tempNationalNumber)
+		}
+		return aytf.accruedInput.String()
+	}
+	return aytf.prefixBeforeNationalNumber.String()
+}
+
+// isNanpaNumberWithNationalPrefix returns true if the current country is a NANPA
+// country and the national number begins with the national prefix.
+func (aytf *AsYouTypeFormatter) isNanpaNumberWithNationalPrefix() bool {
+	// For NANPA numbers beginning with 1[2-9], treat the 1 as the national prefix.
+	// The reason is that national significant numbers in NANPA always start with [2-9]
+	// after the national prefix. Numbers beginning with 1[01] can only be
+	// short/emergency numbers, which don't need the national prefix.
+	return aytf.currentMetadata.GetCountryCode() == 1 && aytf.nationalNumber.Len() >= 2 &&
+		aytf.nationalNumber.charAt(0) == '1' &&
+		aytf.nationalNumber.charAt(1) != '0' && aytf.nationalNumber.charAt(1) != '1'
+}
+
+// removeNationalPrefixFromNationalNumber returns the national prefix extracted,
+// or an empty string if it is not present.
+func (aytf *AsYouTypeFormatter) removeNationalPrefixFromNationalNumber() string {
+	startOfNationalNumber := 0
+	if aytf.isNanpaNumberWithNationalPrefix() {
+		startOfNationalNumber = 1
+		aytf.prefixBeforeNationalNumber.WriteByte('1')
+		aytf.prefixBeforeNationalNumber.WriteByte(byte(SEPARATOR_BEFORE_NATIONAL_NUMBER))
+		aytf.isCompleteNumber = true
+	} else if len(aytf.currentMetadata.GetNationalPrefixForParsing()) > 0 {
+		nationalPrefixForParsing := regexFor("^(?:" + aytf.currentMetadata.GetNationalPrefixForParsing() + ")")
+		// Since some national prefix patterns are entirely optional, check that a national
+		// prefix could actually be extracted.
+		loc := nationalPrefixForParsing.FindStringIndex(aytf.nationalNumber.String())
+		if loc != nil && loc[1] > 0 {
+			// When the national prefix is detected, we use international formatting rules
+			// instead of national ones, because national formatting rules could contain local
+			// formatting rules for numbers entered without area code.
+			aytf.isCompleteNumber = true
+			startOfNationalNumber = loc[1]
+			aytf.prefixBeforeNationalNumber.WriteString(aytf.nationalNumber.substring(0, startOfNationalNumber))
+		}
+	}
+	nationalPrefix := aytf.nationalNumber.substring(0, startOfNationalNumber)
+	aytf.nationalNumber.delete(0, startOfNationalNumber)
+	return nationalPrefix
+}
+
+// attemptToExtractIdd extracts IDD and plus sign to prefixBeforeNationalNumber
+// when they are available, and places the remaining input into nationalNumber. It
+// returns true when accruedInputWithoutFormatting begins with the plus sign or
+// valid IDD for defaultCountry.
+func (aytf *AsYouTypeFormatter) attemptToExtractIdd() bool {
+	internationalPrefix := regexFor("^(?:" + "\\" + string(PLUS_SIGN) + "|" +
+		aytf.currentMetadata.GetInternationalPrefix() + ")")
+	accruedInputWithoutFormatting := aytf.accruedInputWithoutFormatting.String()
+	loc := internationalPrefix.FindStringIndex(accruedInputWithoutFormatting)
+	if loc != nil {
+		aytf.isCompleteNumber = true
+		startOfCountryCallingCode := loc[1]
+		aytf.nationalNumber.Reset()
+		aytf.nationalNumber.WriteString(accruedInputWithoutFormatting[startOfCountryCallingCode:])
+		aytf.prefixBeforeNationalNumber.Reset()
+		aytf.prefixBeforeNationalNumber.WriteString(accruedInputWithoutFormatting[:startOfCountryCallingCode])
+		if aytf.accruedInputWithoutFormatting.charAt(0) != byte(PLUS_SIGN) {
+			aytf.prefixBeforeNationalNumber.WriteByte(byte(SEPARATOR_BEFORE_NATIONAL_NUMBER))
+		}
+		return true
+	}
+	return false
+}
+
+// attemptToExtractCountryCallingCode extracts the country calling code from the
+// beginning of nationalNumber to prefixBeforeNationalNumber when available, and
+// places the remaining input into nationalNumber. It returns true when a valid
+// country calling code can be found.
+func (aytf *AsYouTypeFormatter) attemptToExtractCountryCallingCode() bool {
+	if aytf.nationalNumber.Len() == 0 {
+		return false
+	}
+	numberWithoutCountryCallingCode := NewStringBuilder(nil)
+	countryCode := extractCountryCode(aytf.nationalNumber, numberWithoutCountryCallingCode)
+	if countryCode == 0 {
+		return false
+	}
+	aytf.nationalNumber.Reset()
+	aytf.nationalNumber.Write(numberWithoutCountryCallingCode.Bytes())
+	newRegionCode := GetRegionCodeForCountryCode(countryCode)
+	if REGION_CODE_FOR_NON_GEO_ENTITY == newRegionCode {
+		aytf.currentMetadata = getMetadataForNonGeographicalRegion(countryCode)
+	} else if newRegionCode != aytf.defaultCountry {
+		aytf.currentMetadata = aytf.getMetadataForRegion(newRegionCode)
+	}
+	countryCodeString := strconv.Itoa(countryCode)
+	aytf.prefixBeforeNationalNumber.WriteString(countryCodeString)
+	aytf.prefixBeforeNationalNumber.WriteByte(byte(SEPARATOR_BEFORE_NATIONAL_NUMBER))
+	// When we have successfully extracted the IDD, the previously extracted NDD should
+	// be cleared because it is no longer valid.
+	aytf.extractedNationalPrefix = ""
+	return true
+}
+
+// normalizeAndAccrueDigitsAndPlusSign accrues digits and the plus sign to
+// accruedInputWithoutFormatting for later use. If nextChar contains a digit in
+// non-ASCII format (e.g. the full-width version of digits), it is first
+// normalized to the ASCII version. The return value is nextChar itself, or its
+// normalized version, if nextChar is a digit in non-ASCII format. This method
+// assumes its input is either a digit or the plus sign.
+func (aytf *AsYouTypeFormatter) normalizeAndAccrueDigitsAndPlusSign(nextChar rune, rememberPosition bool) rune {
+	var normalizedChar rune
+	if nextChar == PLUS_SIGN {
+		normalizedChar = nextChar
+		aytf.accruedInputWithoutFormatting.WriteRune(nextChar)
+	} else {
+		if v, ok := arabicIndicNumberals[nextChar]; ok {
+			normalizedChar = v
+		} else {
+			normalizedChar = nextChar
+		}
+		aytf.accruedInputWithoutFormatting.WriteRune(normalizedChar)
+		aytf.nationalNumber.WriteRune(normalizedChar)
+	}
+	if rememberPosition {
+		aytf.positionToRemember = utf8.RuneCount(aytf.accruedInputWithoutFormatting.Bytes())
+	}
+	return normalizedChar
+}
+
+func (aytf *AsYouTypeFormatter) inputDigitHelper(nextChar rune) string {
+	// Note that formattingTemplate is not guaranteed to have a value, it could be
+	// empty, e.g. when the next digit is entered after extracting an IDD or NDD.
+	// Find the next DIGIT_PLACEHOLDER at or after lastMatchPosition; because every
+	// placeholder before lastMatchPosition has already been filled in with a digit,
+	// this is also the first remaining placeholder overall.
+	idx := -1
+	for i := aytf.lastMatchPosition; i < len(aytf.formattingTemplate); i++ {
+		if aytf.formattingTemplate[i] == digitPlaceholderRune {
+			idx = i
+			break
+		}
+	}
+	if idx >= 0 {
+		aytf.formattingTemplate[idx] = nextChar
+		aytf.lastMatchPosition = idx
+		return string(aytf.formattingTemplate[:aytf.lastMatchPosition+1])
+	}
+	if len(aytf.possibleFormats) == 1 {
+		// More digits are entered than we could handle, and there are no other valid
+		// patterns to try.
+		aytf.ableToFormat = false
+	} // else, we just reset the formatting pattern.
+	aytf.currentFormattingPattern = ""
+	return aytf.accruedInput.String()
+}

--- a/asyoutypeformatter_test.go
+++ b/asyoutypeformatter_test.go
@@ -1,0 +1,1208 @@
+package phonenumbers
+
+// Faithful port of upstream libphonenumber's AsYouTypeFormatterTest.java. As
+// upstream notes, these tests use the synthetic test metadata, not the normal
+// metadata file, so they are illustrative of functionality rather than a
+// regression test of real-world data. Each test starts with useTestMetadata(t)
+// (the analogue of TestMetadataTestCase.setUp) and therefore must not run in
+// parallel. Method names and assertions mirror the Java; non-ASCII inputs use the
+// same \u escapes as upstream. Last reconciled against: v9.0.32
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidRegion(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.ZZ)
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+4", f.InputDigit('4'))
+	require.Equal(t, "+48 ", f.InputDigit('8'))
+	require.Equal(t, "+48 8", f.InputDigit('8'))
+	require.Equal(t, "+48 88", f.InputDigit('8'))
+	require.Equal(t, "+48 88 1", f.InputDigit('1'))
+	require.Equal(t, "+48 88 12", f.InputDigit('2'))
+	require.Equal(t, "+48 88 123", f.InputDigit('3'))
+	require.Equal(t, "+48 88 123 1", f.InputDigit('1'))
+	require.Equal(t, "+48 88 123 12", f.InputDigit('2'))
+
+	f.Clear()
+	require.Equal(t, "6", f.InputDigit('6'))
+	require.Equal(t, "65", f.InputDigit('5'))
+	require.Equal(t, "650", f.InputDigit('0'))
+	require.Equal(t, "6502", f.InputDigit('2'))
+	require.Equal(t, "65025", f.InputDigit('5'))
+	require.Equal(t, "650253", f.InputDigit('3'))
+}
+
+func TestInvalidPlusSign(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.ZZ)
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+4", f.InputDigit('4'))
+	require.Equal(t, "+48 ", f.InputDigit('8'))
+	require.Equal(t, "+48 8", f.InputDigit('8'))
+	require.Equal(t, "+48 88", f.InputDigit('8'))
+	require.Equal(t, "+48 88 1", f.InputDigit('1'))
+	require.Equal(t, "+48 88 12", f.InputDigit('2'))
+	require.Equal(t, "+48 88 123", f.InputDigit('3'))
+	require.Equal(t, "+48 88 123 1", f.InputDigit('1'))
+	// A plus sign can only appear at the beginning of the number; otherwise, no
+	// formatting is applied.
+	require.Equal(t, "+48881231+", f.InputDigit('+'))
+	require.Equal(t, "+48881231+2", f.InputDigit('2'))
+}
+
+func TestTooLongNumberMatchingMultipleLeadingDigits(t *testing.T) {
+	useTestMetadata(t)
+	// See https://github.com/google/libphonenumber/issues/36
+	// The bug occurred last time for countries which have two formatting rules with
+	// exactly the same leading digits pattern but differ in length.
+	f := GetAsYouTypeFormatter(regionCode.ZZ)
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+81 ", f.InputDigit('1'))
+	require.Equal(t, "+81 9", f.InputDigit('9'))
+	require.Equal(t, "+81 90", f.InputDigit('0'))
+	require.Equal(t, "+81 90 1", f.InputDigit('1'))
+	require.Equal(t, "+81 90 12", f.InputDigit('2'))
+	require.Equal(t, "+81 90 123", f.InputDigit('3'))
+	require.Equal(t, "+81 90 1234", f.InputDigit('4'))
+	require.Equal(t, "+81 90 1234 5", f.InputDigit('5'))
+	require.Equal(t, "+81 90 1234 56", f.InputDigit('6'))
+	require.Equal(t, "+81 90 1234 567", f.InputDigit('7'))
+	require.Equal(t, "+81 90 1234 5678", f.InputDigit('8'))
+	require.Equal(t, "+81 90 12 345 6789", f.InputDigit('9'))
+	require.Equal(t, "+81901234567890", f.InputDigit('0'))
+	require.Equal(t, "+819012345678901", f.InputDigit('1'))
+}
+
+func TestCountryWithSpaceInNationalPrefixFormattingRule(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.BY)
+	require.Equal(t, "8", f.InputDigit('8'))
+	require.Equal(t, "88", f.InputDigit('8'))
+	require.Equal(t, "881", f.InputDigit('1'))
+	require.Equal(t, "8 819", f.InputDigit('9'))
+	require.Equal(t, "8 8190", f.InputDigit('0'))
+	// The formatting rule for 5 digit numbers states that no space should be present
+	// after the national prefix.
+	require.Equal(t, "881 901", f.InputDigit('1'))
+	require.Equal(t, "8 819 012", f.InputDigit('2'))
+	// Too long, no formatting rule applies.
+	require.Equal(t, "88190123", f.InputDigit('3'))
+}
+
+func TestCountryWithSpaceInNationalPrefixFormattingRuleAndLongNdd(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.BY)
+	require.Equal(t, "9", f.InputDigit('9'))
+	require.Equal(t, "99", f.InputDigit('9'))
+	require.Equal(t, "999", f.InputDigit('9'))
+	require.Equal(t, "9999", f.InputDigit('9'))
+	require.Equal(t, "99999 ", f.InputDigit('9'))
+	require.Equal(t, "99999 1", f.InputDigit('1'))
+	require.Equal(t, "99999 12", f.InputDigit('2'))
+	require.Equal(t, "99999 123", f.InputDigit('3'))
+	require.Equal(t, "99999 1234", f.InputDigit('4'))
+	require.Equal(t, "99999 12 345", f.InputDigit('5'))
+}
+
+func TestAYTFUS(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.US)
+	require.Equal(t, "6", f.InputDigit('6'))
+	require.Equal(t, "65", f.InputDigit('5'))
+	require.Equal(t, "650", f.InputDigit('0'))
+	require.Equal(t, "650 2", f.InputDigit('2'))
+	require.Equal(t, "650 25", f.InputDigit('5'))
+	require.Equal(t, "650 253", f.InputDigit('3'))
+	// Note this is how a US local number (without area code) should be formatted.
+	require.Equal(t, "650 2532", f.InputDigit('2'))
+	require.Equal(t, "650 253 22", f.InputDigit('2'))
+	require.Equal(t, "650 253 222", f.InputDigit('2'))
+	require.Equal(t, "650 253 2222", f.InputDigit('2'))
+
+	f.Clear()
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "16", f.InputDigit('6'))
+	require.Equal(t, "1 65", f.InputDigit('5'))
+	require.Equal(t, "1 650", f.InputDigit('0'))
+	require.Equal(t, "1 650 2", f.InputDigit('2'))
+	require.Equal(t, "1 650 25", f.InputDigit('5'))
+	require.Equal(t, "1 650 253", f.InputDigit('3'))
+	require.Equal(t, "1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, "1 650 253 222", f.InputDigit('2'))
+	require.Equal(t, "1 650 253 2222", f.InputDigit('2'))
+
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011 ", f.InputDigit('1'))
+	require.Equal(t, "011 4", f.InputDigit('4'))
+	require.Equal(t, "011 44 ", f.InputDigit('4'))
+	require.Equal(t, "011 44 6", f.InputDigit('6'))
+	require.Equal(t, "011 44 61", f.InputDigit('1'))
+	require.Equal(t, "011 44 6 12", f.InputDigit('2'))
+	require.Equal(t, "011 44 6 123", f.InputDigit('3'))
+	require.Equal(t, "011 44 6 123 1", f.InputDigit('1'))
+	require.Equal(t, "011 44 6 123 12", f.InputDigit('2'))
+	require.Equal(t, "011 44 6 123 123", f.InputDigit('3'))
+	require.Equal(t, "011 44 6 123 123 1", f.InputDigit('1'))
+	require.Equal(t, "011 44 6 123 123 12", f.InputDigit('2'))
+	require.Equal(t, "011 44 6 123 123 123", f.InputDigit('3'))
+
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011 ", f.InputDigit('1'))
+	require.Equal(t, "011 5", f.InputDigit('5'))
+	require.Equal(t, "011 54 ", f.InputDigit('4'))
+	require.Equal(t, "011 54 9", f.InputDigit('9'))
+	require.Equal(t, "011 54 91", f.InputDigit('1'))
+	require.Equal(t, "011 54 9 11", f.InputDigit('1'))
+	require.Equal(t, "011 54 9 11 2", f.InputDigit('2'))
+	require.Equal(t, "011 54 9 11 23", f.InputDigit('3'))
+	require.Equal(t, "011 54 9 11 231", f.InputDigit('1'))
+	require.Equal(t, "011 54 9 11 2312", f.InputDigit('2'))
+	require.Equal(t, "011 54 9 11 2312 1", f.InputDigit('1'))
+	require.Equal(t, "011 54 9 11 2312 12", f.InputDigit('2'))
+	require.Equal(t, "011 54 9 11 2312 123", f.InputDigit('3'))
+	require.Equal(t, "011 54 9 11 2312 1234", f.InputDigit('4'))
+
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011 ", f.InputDigit('1'))
+	require.Equal(t, "011 2", f.InputDigit('2'))
+	require.Equal(t, "011 24", f.InputDigit('4'))
+	require.Equal(t, "011 244 ", f.InputDigit('4'))
+	require.Equal(t, "011 244 2", f.InputDigit('2'))
+	require.Equal(t, "011 244 28", f.InputDigit('8'))
+	require.Equal(t, "011 244 280", f.InputDigit('0'))
+	require.Equal(t, "011 244 280 0", f.InputDigit('0'))
+	require.Equal(t, "011 244 280 00", f.InputDigit('0'))
+	require.Equal(t, "011 244 280 000", f.InputDigit('0'))
+	require.Equal(t, "011 244 280 000 0", f.InputDigit('0'))
+	require.Equal(t, "011 244 280 000 00", f.InputDigit('0'))
+	require.Equal(t, "011 244 280 000 000", f.InputDigit('0'))
+
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+4", f.InputDigit('4'))
+	require.Equal(t, "+48 ", f.InputDigit('8'))
+	require.Equal(t, "+48 8", f.InputDigit('8'))
+	require.Equal(t, "+48 88", f.InputDigit('8'))
+	require.Equal(t, "+48 88 1", f.InputDigit('1'))
+	require.Equal(t, "+48 88 12", f.InputDigit('2'))
+	require.Equal(t, "+48 88 123", f.InputDigit('3'))
+	require.Equal(t, "+48 88 123 1", f.InputDigit('1'))
+	require.Equal(t, "+48 88 123 12", f.InputDigit('2'))
+	require.Equal(t, "+48 88 123 12 1", f.InputDigit('1'))
+	require.Equal(t, "+48 88 123 12 12", f.InputDigit('2'))
+}
+
+func TestAYTFUSFullWidthCharacters(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.US)
+	require.Equal(t, "６", f.InputDigit('６'))
+	require.Equal(t, "６５", f.InputDigit('５'))
+	require.Equal(t, "650", f.InputDigit('０'))
+	require.Equal(t, "650 2", f.InputDigit('２'))
+	require.Equal(t, "650 25", f.InputDigit('５'))
+	require.Equal(t, "650 253", f.InputDigit('３'))
+	require.Equal(t, "650 2532", f.InputDigit('２'))
+	require.Equal(t, "650 253 22", f.InputDigit('２'))
+	require.Equal(t, "650 253 222", f.InputDigit('２'))
+	require.Equal(t, "650 253 2222", f.InputDigit('２'))
+}
+
+func TestAYTFUSMobileShortCode(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.US)
+	require.Equal(t, "*", f.InputDigit('*'))
+	require.Equal(t, "*1", f.InputDigit('1'))
+	require.Equal(t, "*12", f.InputDigit('2'))
+	require.Equal(t, "*121", f.InputDigit('1'))
+	require.Equal(t, "*121#", f.InputDigit('#'))
+}
+
+func TestAYTFUSVanityNumber(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.US)
+	require.Equal(t, "8", f.InputDigit('8'))
+	require.Equal(t, "80", f.InputDigit('0'))
+	require.Equal(t, "800", f.InputDigit('0'))
+	require.Equal(t, "800 ", f.InputDigit(' '))
+	require.Equal(t, "800 M", f.InputDigit('M'))
+	require.Equal(t, "800 MY", f.InputDigit('Y'))
+	require.Equal(t, "800 MY ", f.InputDigit(' '))
+	require.Equal(t, "800 MY A", f.InputDigit('A'))
+	require.Equal(t, "800 MY AP", f.InputDigit('P'))
+	require.Equal(t, "800 MY APP", f.InputDigit('P'))
+	require.Equal(t, "800 MY APPL", f.InputDigit('L'))
+	require.Equal(t, "800 MY APPLE", f.InputDigit('E'))
+}
+
+func TestAYTFAndRememberPositionUS(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.US)
+	require.Equal(t, "1", f.InputDigitAndRememberPosition('1'))
+	require.Equal(t, 1, f.GetRememberedPosition())
+	require.Equal(t, "16", f.InputDigit('6'))
+	require.Equal(t, "1 65", f.InputDigit('5'))
+	require.Equal(t, 1, f.GetRememberedPosition())
+	require.Equal(t, "1 650", f.InputDigitAndRememberPosition('0'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "1 650 2", f.InputDigit('2'))
+	require.Equal(t, "1 650 25", f.InputDigit('5'))
+	// Note the remembered position for digit "0" changes from 4 to 5, because a space
+	// is now inserted in the front.
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "1 650 253", f.InputDigit('3'))
+	require.Equal(t, "1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "1 650 253 222", f.InputDigitAndRememberPosition('2'))
+	require.Equal(t, 13, f.GetRememberedPosition())
+	require.Equal(t, "1 650 253 2222", f.InputDigit('2'))
+	require.Equal(t, 13, f.GetRememberedPosition())
+	require.Equal(t, "165025322222", f.InputDigit('2'))
+	require.Equal(t, 10, f.GetRememberedPosition())
+	require.Equal(t, "1650253222222", f.InputDigit('2'))
+	require.Equal(t, 10, f.GetRememberedPosition())
+
+	f.Clear()
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "16", f.InputDigitAndRememberPosition('6'))
+	require.Equal(t, 2, f.GetRememberedPosition())
+	require.Equal(t, "1 65", f.InputDigit('5'))
+	require.Equal(t, "1 650", f.InputDigit('0'))
+	require.Equal(t, 3, f.GetRememberedPosition())
+	require.Equal(t, "1 650 2", f.InputDigit('2'))
+	require.Equal(t, "1 650 25", f.InputDigit('5'))
+	require.Equal(t, 3, f.GetRememberedPosition())
+	require.Equal(t, "1 650 253", f.InputDigit('3'))
+	require.Equal(t, "1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, 3, f.GetRememberedPosition())
+	require.Equal(t, "1 650 253 222", f.InputDigit('2'))
+	require.Equal(t, "1 650 253 2222", f.InputDigit('2'))
+	require.Equal(t, "165025322222", f.InputDigit('2'))
+	require.Equal(t, 2, f.GetRememberedPosition())
+	require.Equal(t, "1650253222222", f.InputDigit('2'))
+	require.Equal(t, 2, f.GetRememberedPosition())
+
+	f.Clear()
+	require.Equal(t, "6", f.InputDigit('6'))
+	require.Equal(t, "65", f.InputDigit('5'))
+	require.Equal(t, "650", f.InputDigit('0'))
+	require.Equal(t, "650 2", f.InputDigit('2'))
+	require.Equal(t, "650 25", f.InputDigit('5'))
+	require.Equal(t, "650 253", f.InputDigit('3'))
+	require.Equal(t, "650 2532", f.InputDigitAndRememberPosition('2'))
+	require.Equal(t, 8, f.GetRememberedPosition())
+	require.Equal(t, "650 253 22", f.InputDigit('2'))
+	require.Equal(t, 9, f.GetRememberedPosition())
+	require.Equal(t, "650 253 222", f.InputDigit('2'))
+	// No more formatting when semicolon is entered.
+	require.Equal(t, "650253222;", f.InputDigit(';'))
+	require.Equal(t, 7, f.GetRememberedPosition())
+	require.Equal(t, "650253222;2", f.InputDigit('2'))
+
+	f.Clear()
+	require.Equal(t, "6", f.InputDigit('6'))
+	require.Equal(t, "65", f.InputDigit('5'))
+	require.Equal(t, "650", f.InputDigit('0'))
+	// No more formatting when users choose to do their own formatting.
+	require.Equal(t, "650-", f.InputDigit('-'))
+	require.Equal(t, "650-2", f.InputDigitAndRememberPosition('2'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "650-25", f.InputDigit('5'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "650-253", f.InputDigit('3'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "650-253-", f.InputDigit('-'))
+	require.Equal(t, "650-253-2", f.InputDigit('2'))
+	require.Equal(t, "650-253-22", f.InputDigit('2'))
+	require.Equal(t, "650-253-222", f.InputDigit('2'))
+	require.Equal(t, "650-253-2222", f.InputDigit('2'))
+
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011 ", f.InputDigit('1'))
+	require.Equal(t, "011 4", f.InputDigitAndRememberPosition('4'))
+	require.Equal(t, "011 48 ", f.InputDigit('8'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "011 48 8", f.InputDigit('8'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "011 48 88", f.InputDigit('8'))
+	require.Equal(t, "011 48 88 1", f.InputDigit('1'))
+	require.Equal(t, "011 48 88 12", f.InputDigit('2'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "011 48 88 123", f.InputDigit('3'))
+	require.Equal(t, "011 48 88 123 1", f.InputDigit('1'))
+	require.Equal(t, "011 48 88 123 12", f.InputDigit('2'))
+	require.Equal(t, "011 48 88 123 12 1", f.InputDigit('1'))
+	require.Equal(t, "011 48 88 123 12 12", f.InputDigit('2'))
+
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+1", f.InputDigit('1'))
+	require.Equal(t, "+1 6", f.InputDigitAndRememberPosition('6'))
+	require.Equal(t, "+1 65", f.InputDigit('5'))
+	require.Equal(t, "+1 650", f.InputDigit('0'))
+	require.Equal(t, 4, f.GetRememberedPosition())
+	require.Equal(t, "+1 650 2", f.InputDigit('2'))
+	require.Equal(t, 4, f.GetRememberedPosition())
+	require.Equal(t, "+1 650 25", f.InputDigit('5'))
+	require.Equal(t, "+1 650 253", f.InputDigitAndRememberPosition('3'))
+	require.Equal(t, "+1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "+1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, "+1 650 253 222", f.InputDigit('2'))
+	require.Equal(t, 10, f.GetRememberedPosition())
+
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+1", f.InputDigit('1'))
+	require.Equal(t, "+1 6", f.InputDigitAndRememberPosition('6'))
+	require.Equal(t, "+1 65", f.InputDigit('5'))
+	require.Equal(t, "+1 650", f.InputDigit('0'))
+	require.Equal(t, 4, f.GetRememberedPosition())
+	require.Equal(t, "+1 650 2", f.InputDigit('2'))
+	require.Equal(t, 4, f.GetRememberedPosition())
+	require.Equal(t, "+1 650 25", f.InputDigit('5'))
+	require.Equal(t, "+1 650 253", f.InputDigit('3'))
+	require.Equal(t, "+1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "+1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, "+1 650 253 222", f.InputDigit('2'))
+	require.Equal(t, "+1650253222;", f.InputDigit(';'))
+	require.Equal(t, 3, f.GetRememberedPosition())
+}
+
+func TestAYTFGBFixedLine(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.GB)
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "02", f.InputDigit('2'))
+	require.Equal(t, "020", f.InputDigit('0'))
+	require.Equal(t, "020 7", f.InputDigitAndRememberPosition('7'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "020 70", f.InputDigit('0'))
+	require.Equal(t, "020 703", f.InputDigit('3'))
+	require.Equal(t, 5, f.GetRememberedPosition())
+	require.Equal(t, "020 7031", f.InputDigit('1'))
+	require.Equal(t, "020 7031 3", f.InputDigit('3'))
+	require.Equal(t, "020 7031 30", f.InputDigit('0'))
+	require.Equal(t, "020 7031 300", f.InputDigit('0'))
+	require.Equal(t, "020 7031 3000", f.InputDigit('0'))
+}
+
+func TestAYTFGBTollFree(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.GB)
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "08", f.InputDigit('8'))
+	require.Equal(t, "080", f.InputDigit('0'))
+	require.Equal(t, "080 7", f.InputDigit('7'))
+	require.Equal(t, "080 70", f.InputDigit('0'))
+	require.Equal(t, "080 703", f.InputDigit('3'))
+	require.Equal(t, "080 7031", f.InputDigit('1'))
+	require.Equal(t, "080 7031 3", f.InputDigit('3'))
+	require.Equal(t, "080 7031 30", f.InputDigit('0'))
+	require.Equal(t, "080 7031 300", f.InputDigit('0'))
+	require.Equal(t, "080 7031 3000", f.InputDigit('0'))
+}
+
+func TestAYTFGBPremiumRate(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.GB)
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "09", f.InputDigit('9'))
+	require.Equal(t, "090", f.InputDigit('0'))
+	require.Equal(t, "090 7", f.InputDigit('7'))
+	require.Equal(t, "090 70", f.InputDigit('0'))
+	require.Equal(t, "090 703", f.InputDigit('3'))
+	require.Equal(t, "090 7031", f.InputDigit('1'))
+	require.Equal(t, "090 7031 3", f.InputDigit('3'))
+	require.Equal(t, "090 7031 30", f.InputDigit('0'))
+	require.Equal(t, "090 7031 300", f.InputDigit('0'))
+	require.Equal(t, "090 7031 3000", f.InputDigit('0'))
+}
+
+func TestAYTFNZMobile(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.NZ)
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "02", f.InputDigit('2'))
+	require.Equal(t, "021", f.InputDigit('1'))
+	require.Equal(t, "02-11", f.InputDigit('1'))
+	require.Equal(t, "02-112", f.InputDigit('2'))
+	// Note the unittest is using fake metadata which might produce non-ideal results.
+	require.Equal(t, "02-112 3", f.InputDigit('3'))
+	require.Equal(t, "02-112 34", f.InputDigit('4'))
+	require.Equal(t, "02-112 345", f.InputDigit('5'))
+	require.Equal(t, "02-112 3456", f.InputDigit('6'))
+}
+
+func TestAYTFDE(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.DE)
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "03", f.InputDigit('3'))
+	require.Equal(t, "030", f.InputDigit('0'))
+	require.Equal(t, "030/1", f.InputDigit('1'))
+	require.Equal(t, "030/12", f.InputDigit('2'))
+	require.Equal(t, "030/123", f.InputDigit('3'))
+	require.Equal(t, "030/1234", f.InputDigit('4'))
+
+	// 04134 1234
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "04", f.InputDigit('4'))
+	require.Equal(t, "041", f.InputDigit('1'))
+	require.Equal(t, "041 3", f.InputDigit('3'))
+	require.Equal(t, "041 34", f.InputDigit('4'))
+	require.Equal(t, "04134 1", f.InputDigit('1'))
+	require.Equal(t, "04134 12", f.InputDigit('2'))
+	require.Equal(t, "04134 123", f.InputDigit('3'))
+	require.Equal(t, "04134 1234", f.InputDigit('4'))
+
+	// 08021 2345
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "08", f.InputDigit('8'))
+	require.Equal(t, "080", f.InputDigit('0'))
+	require.Equal(t, "080 2", f.InputDigit('2'))
+	require.Equal(t, "080 21", f.InputDigit('1'))
+	require.Equal(t, "08021 2", f.InputDigit('2'))
+	require.Equal(t, "08021 23", f.InputDigit('3'))
+	require.Equal(t, "08021 234", f.InputDigit('4'))
+	require.Equal(t, "08021 2345", f.InputDigit('5'))
+
+	// 00 1 650 253 2250
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "00", f.InputDigit('0'))
+	require.Equal(t, "00 1 ", f.InputDigit('1'))
+	require.Equal(t, "00 1 6", f.InputDigit('6'))
+	require.Equal(t, "00 1 65", f.InputDigit('5'))
+	require.Equal(t, "00 1 650", f.InputDigit('0'))
+	require.Equal(t, "00 1 650 2", f.InputDigit('2'))
+	require.Equal(t, "00 1 650 25", f.InputDigit('5'))
+	require.Equal(t, "00 1 650 253", f.InputDigit('3'))
+	require.Equal(t, "00 1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "00 1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, "00 1 650 253 222", f.InputDigit('2'))
+	require.Equal(t, "00 1 650 253 2222", f.InputDigit('2'))
+}
+
+func TestAYTFAR(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.AR)
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011", f.InputDigit('1'))
+	require.Equal(t, "011 7", f.InputDigit('7'))
+	require.Equal(t, "011 70", f.InputDigit('0'))
+	require.Equal(t, "011 703", f.InputDigit('3'))
+	require.Equal(t, "011 7031", f.InputDigit('1'))
+	require.Equal(t, "011 7031-3", f.InputDigit('3'))
+	require.Equal(t, "011 7031-30", f.InputDigit('0'))
+	require.Equal(t, "011 7031-300", f.InputDigit('0'))
+	require.Equal(t, "011 7031-3000", f.InputDigit('0'))
+}
+
+func TestAYTFARMobile(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.AR)
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+5", f.InputDigit('5'))
+	require.Equal(t, "+54 ", f.InputDigit('4'))
+	require.Equal(t, "+54 9", f.InputDigit('9'))
+	require.Equal(t, "+54 91", f.InputDigit('1'))
+	require.Equal(t, "+54 9 11", f.InputDigit('1'))
+	require.Equal(t, "+54 9 11 2", f.InputDigit('2'))
+	require.Equal(t, "+54 9 11 23", f.InputDigit('3'))
+	require.Equal(t, "+54 9 11 231", f.InputDigit('1'))
+	require.Equal(t, "+54 9 11 2312", f.InputDigit('2'))
+	require.Equal(t, "+54 9 11 2312 1", f.InputDigit('1'))
+	require.Equal(t, "+54 9 11 2312 12", f.InputDigit('2'))
+	require.Equal(t, "+54 9 11 2312 123", f.InputDigit('3'))
+	require.Equal(t, "+54 9 11 2312 1234", f.InputDigit('4'))
+}
+
+func TestAYTFKR(t *testing.T) {
+	useTestMetadata(t)
+	// +82 51 234 5678
+	f := GetAsYouTypeFormatter(regionCode.KR)
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+82 ", f.InputDigit('2'))
+	require.Equal(t, "+82 5", f.InputDigit('5'))
+	require.Equal(t, "+82 51", f.InputDigit('1'))
+	require.Equal(t, "+82 51-2", f.InputDigit('2'))
+	require.Equal(t, "+82 51-23", f.InputDigit('3'))
+	require.Equal(t, "+82 51-234", f.InputDigit('4'))
+	require.Equal(t, "+82 51-234-5", f.InputDigit('5'))
+	require.Equal(t, "+82 51-234-56", f.InputDigit('6'))
+	require.Equal(t, "+82 51-234-567", f.InputDigit('7'))
+	require.Equal(t, "+82 51-234-5678", f.InputDigit('8'))
+
+	// +82 2 531 5678
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+82 ", f.InputDigit('2'))
+	require.Equal(t, "+82 2", f.InputDigit('2'))
+	require.Equal(t, "+82 25", f.InputDigit('5'))
+	require.Equal(t, "+82 2-53", f.InputDigit('3'))
+	require.Equal(t, "+82 2-531", f.InputDigit('1'))
+	require.Equal(t, "+82 2-531-5", f.InputDigit('5'))
+	require.Equal(t, "+82 2-531-56", f.InputDigit('6'))
+	require.Equal(t, "+82 2-531-567", f.InputDigit('7'))
+	require.Equal(t, "+82 2-531-5678", f.InputDigit('8'))
+
+	// +82 2 3665 5678
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+82 ", f.InputDigit('2'))
+	require.Equal(t, "+82 2", f.InputDigit('2'))
+	require.Equal(t, "+82 23", f.InputDigit('3'))
+	require.Equal(t, "+82 2-36", f.InputDigit('6'))
+	require.Equal(t, "+82 2-366", f.InputDigit('6'))
+	require.Equal(t, "+82 2-3665", f.InputDigit('5'))
+	require.Equal(t, "+82 2-3665-5", f.InputDigit('5'))
+	require.Equal(t, "+82 2-3665-56", f.InputDigit('6'))
+	require.Equal(t, "+82 2-3665-567", f.InputDigit('7'))
+	require.Equal(t, "+82 2-3665-5678", f.InputDigit('8'))
+
+	// 02-114
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "02", f.InputDigit('2'))
+	require.Equal(t, "021", f.InputDigit('1'))
+	require.Equal(t, "02-11", f.InputDigit('1'))
+	require.Equal(t, "02-114", f.InputDigit('4'))
+
+	// 02-1300
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "02", f.InputDigit('2'))
+	require.Equal(t, "021", f.InputDigit('1'))
+	require.Equal(t, "02-13", f.InputDigit('3'))
+	require.Equal(t, "02-130", f.InputDigit('0'))
+	require.Equal(t, "02-1300", f.InputDigit('0'))
+
+	// 011-456-7890
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011", f.InputDigit('1'))
+	require.Equal(t, "011-4", f.InputDigit('4'))
+	require.Equal(t, "011-45", f.InputDigit('5'))
+	require.Equal(t, "011-456", f.InputDigit('6'))
+	require.Equal(t, "011-456-7", f.InputDigit('7'))
+	require.Equal(t, "011-456-78", f.InputDigit('8'))
+	require.Equal(t, "011-456-789", f.InputDigit('9'))
+	require.Equal(t, "011-456-7890", f.InputDigit('0'))
+
+	// 011-9876-7890
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011", f.InputDigit('1'))
+	require.Equal(t, "011-9", f.InputDigit('9'))
+	require.Equal(t, "011-98", f.InputDigit('8'))
+	require.Equal(t, "011-987", f.InputDigit('7'))
+	require.Equal(t, "011-9876", f.InputDigit('6'))
+	require.Equal(t, "011-9876-7", f.InputDigit('7'))
+	require.Equal(t, "011-9876-78", f.InputDigit('8'))
+	require.Equal(t, "011-9876-789", f.InputDigit('9'))
+	require.Equal(t, "011-9876-7890", f.InputDigit('0'))
+}
+
+func TestAYTF_MX(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.MX)
+
+	// +52 800 123 4567
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+5", f.InputDigit('5'))
+	require.Equal(t, "+52 ", f.InputDigit('2'))
+	require.Equal(t, "+52 8", f.InputDigit('8'))
+	require.Equal(t, "+52 80", f.InputDigit('0'))
+	require.Equal(t, "+52 800", f.InputDigit('0'))
+	require.Equal(t, "+52 800 1", f.InputDigit('1'))
+	require.Equal(t, "+52 800 12", f.InputDigit('2'))
+	require.Equal(t, "+52 800 123", f.InputDigit('3'))
+	require.Equal(t, "+52 800 123 4", f.InputDigit('4'))
+	require.Equal(t, "+52 800 123 45", f.InputDigit('5'))
+	require.Equal(t, "+52 800 123 456", f.InputDigit('6'))
+	require.Equal(t, "+52 800 123 4567", f.InputDigit('7'))
+
+	// +529011234567, proactively ensuring that no formatting is applied, where a
+	// format is chosen that would otherwise have led to some digits being dropped.
+	f.Clear()
+	require.Equal(t, "9", f.InputDigit('9'))
+	require.Equal(t, "90", f.InputDigit('0'))
+	require.Equal(t, "901", f.InputDigit('1'))
+	require.Equal(t, "9011", f.InputDigit('1'))
+	require.Equal(t, "90112", f.InputDigit('2'))
+	require.Equal(t, "901123", f.InputDigit('3'))
+	require.Equal(t, "9011234", f.InputDigit('4'))
+	require.Equal(t, "90112345", f.InputDigit('5'))
+	require.Equal(t, "901123456", f.InputDigit('6'))
+	require.Equal(t, "9011234567", f.InputDigit('7'))
+
+	// +52 55 1234 5678
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+5", f.InputDigit('5'))
+	require.Equal(t, "+52 ", f.InputDigit('2'))
+	require.Equal(t, "+52 5", f.InputDigit('5'))
+	require.Equal(t, "+52 55", f.InputDigit('5'))
+	require.Equal(t, "+52 55 1", f.InputDigit('1'))
+	require.Equal(t, "+52 55 12", f.InputDigit('2'))
+	require.Equal(t, "+52 55 123", f.InputDigit('3'))
+	require.Equal(t, "+52 55 1234", f.InputDigit('4'))
+	require.Equal(t, "+52 55 1234 5", f.InputDigit('5'))
+	require.Equal(t, "+52 55 1234 56", f.InputDigit('6'))
+	require.Equal(t, "+52 55 1234 567", f.InputDigit('7'))
+	require.Equal(t, "+52 55 1234 5678", f.InputDigit('8'))
+
+	// +52 212 345 6789
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+5", f.InputDigit('5'))
+	require.Equal(t, "+52 ", f.InputDigit('2'))
+	require.Equal(t, "+52 2", f.InputDigit('2'))
+	require.Equal(t, "+52 21", f.InputDigit('1'))
+	require.Equal(t, "+52 212", f.InputDigit('2'))
+	require.Equal(t, "+52 212 3", f.InputDigit('3'))
+	require.Equal(t, "+52 212 34", f.InputDigit('4'))
+	require.Equal(t, "+52 212 345", f.InputDigit('5'))
+	require.Equal(t, "+52 212 345 6", f.InputDigit('6'))
+	require.Equal(t, "+52 212 345 67", f.InputDigit('7'))
+	require.Equal(t, "+52 212 345 678", f.InputDigit('8'))
+	require.Equal(t, "+52 212 345 6789", f.InputDigit('9'))
+
+	// +52 1 55 1234 5678
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+5", f.InputDigit('5'))
+	require.Equal(t, "+52 ", f.InputDigit('2'))
+	require.Equal(t, "+52 1", f.InputDigit('1'))
+	require.Equal(t, "+52 15", f.InputDigit('5'))
+	require.Equal(t, "+52 1 55", f.InputDigit('5'))
+	require.Equal(t, "+52 1 55 1", f.InputDigit('1'))
+	require.Equal(t, "+52 1 55 12", f.InputDigit('2'))
+	require.Equal(t, "+52 1 55 123", f.InputDigit('3'))
+	require.Equal(t, "+52 1 55 1234", f.InputDigit('4'))
+	require.Equal(t, "+52 1 55 1234 5", f.InputDigit('5'))
+	require.Equal(t, "+52 1 55 1234 56", f.InputDigit('6'))
+	require.Equal(t, "+52 1 55 1234 567", f.InputDigit('7'))
+	require.Equal(t, "+52 1 55 1234 5678", f.InputDigit('8'))
+
+	// +52 1 541 234 5678
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+5", f.InputDigit('5'))
+	require.Equal(t, "+52 ", f.InputDigit('2'))
+	require.Equal(t, "+52 1", f.InputDigit('1'))
+	require.Equal(t, "+52 15", f.InputDigit('5'))
+	require.Equal(t, "+52 1 54", f.InputDigit('4'))
+	require.Equal(t, "+52 1 541", f.InputDigit('1'))
+	require.Equal(t, "+52 1 541 2", f.InputDigit('2'))
+	require.Equal(t, "+52 1 541 23", f.InputDigit('3'))
+	require.Equal(t, "+52 1 541 234", f.InputDigit('4'))
+	require.Equal(t, "+52 1 541 234 5", f.InputDigit('5'))
+	require.Equal(t, "+52 1 541 234 56", f.InputDigit('6'))
+	require.Equal(t, "+52 1 541 234 567", f.InputDigit('7'))
+	require.Equal(t, "+52 1 541 234 5678", f.InputDigit('8'))
+}
+
+func TestAYTF_International_Toll_Free(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.US)
+	// +800 1234 5678
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+80", f.InputDigit('0'))
+	require.Equal(t, "+800 ", f.InputDigit('0'))
+	require.Equal(t, "+800 1", f.InputDigit('1'))
+	require.Equal(t, "+800 12", f.InputDigit('2'))
+	require.Equal(t, "+800 123", f.InputDigit('3'))
+	require.Equal(t, "+800 1234", f.InputDigit('4'))
+	require.Equal(t, "+800 1234 5", f.InputDigit('5'))
+	require.Equal(t, "+800 1234 56", f.InputDigit('6'))
+	require.Equal(t, "+800 1234 567", f.InputDigit('7'))
+	require.Equal(t, "+800 1234 5678", f.InputDigit('8'))
+	require.Equal(t, "+800123456789", f.InputDigit('9'))
+}
+
+func TestAYTFMultipleLeadingDigitPatterns(t *testing.T) {
+	useTestMetadata(t)
+	// +81 50 2345 6789
+	f := GetAsYouTypeFormatter(regionCode.JP)
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+81 ", f.InputDigit('1'))
+	require.Equal(t, "+81 5", f.InputDigit('5'))
+	require.Equal(t, "+81 50", f.InputDigit('0'))
+	require.Equal(t, "+81 50 2", f.InputDigit('2'))
+	require.Equal(t, "+81 50 23", f.InputDigit('3'))
+	require.Equal(t, "+81 50 234", f.InputDigit('4'))
+	require.Equal(t, "+81 50 2345", f.InputDigit('5'))
+	require.Equal(t, "+81 50 2345 6", f.InputDigit('6'))
+	require.Equal(t, "+81 50 2345 67", f.InputDigit('7'))
+	require.Equal(t, "+81 50 2345 678", f.InputDigit('8'))
+	require.Equal(t, "+81 50 2345 6789", f.InputDigit('9'))
+
+	// +81 222 12 5678
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+81 ", f.InputDigit('1'))
+	require.Equal(t, "+81 2", f.InputDigit('2'))
+	require.Equal(t, "+81 22", f.InputDigit('2'))
+	require.Equal(t, "+81 22 2", f.InputDigit('2'))
+	require.Equal(t, "+81 22 21", f.InputDigit('1'))
+	require.Equal(t, "+81 2221 2", f.InputDigit('2'))
+	require.Equal(t, "+81 222 12 5", f.InputDigit('5'))
+	require.Equal(t, "+81 222 12 56", f.InputDigit('6'))
+	require.Equal(t, "+81 222 12 567", f.InputDigit('7'))
+	require.Equal(t, "+81 222 12 5678", f.InputDigit('8'))
+
+	// 011113
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "01", f.InputDigit('1'))
+	require.Equal(t, "011", f.InputDigit('1'))
+	require.Equal(t, "011 1", f.InputDigit('1'))
+	require.Equal(t, "011 11", f.InputDigit('1'))
+	require.Equal(t, "011113", f.InputDigit('3'))
+
+	// +81 3332 2 5678
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+81 ", f.InputDigit('1'))
+	require.Equal(t, "+81 3", f.InputDigit('3'))
+	require.Equal(t, "+81 33", f.InputDigit('3'))
+	require.Equal(t, "+81 33 3", f.InputDigit('3'))
+	require.Equal(t, "+81 3332", f.InputDigit('2'))
+	require.Equal(t, "+81 3332 2", f.InputDigit('2'))
+	require.Equal(t, "+81 3332 2 5", f.InputDigit('5'))
+	require.Equal(t, "+81 3332 2 56", f.InputDigit('6'))
+	require.Equal(t, "+81 3332 2 567", f.InputDigit('7'))
+	require.Equal(t, "+81 3332 2 5678", f.InputDigit('8'))
+}
+
+func TestAYTFLongIDD_AU(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.AU)
+	// 0011 1 650 253 2250
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "00", f.InputDigit('0'))
+	require.Equal(t, "001", f.InputDigit('1'))
+	require.Equal(t, "0011", f.InputDigit('1'))
+	require.Equal(t, "0011 1 ", f.InputDigit('1'))
+	require.Equal(t, "0011 1 6", f.InputDigit('6'))
+	require.Equal(t, "0011 1 65", f.InputDigit('5'))
+	require.Equal(t, "0011 1 650", f.InputDigit('0'))
+	require.Equal(t, "0011 1 650 2", f.InputDigit('2'))
+	require.Equal(t, "0011 1 650 25", f.InputDigit('5'))
+	require.Equal(t, "0011 1 650 253", f.InputDigit('3'))
+	require.Equal(t, "0011 1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "0011 1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, "0011 1 650 253 222", f.InputDigit('2'))
+	require.Equal(t, "0011 1 650 253 2222", f.InputDigit('2'))
+
+	// 0011 81 3332 2 5678
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "00", f.InputDigit('0'))
+	require.Equal(t, "001", f.InputDigit('1'))
+	require.Equal(t, "0011", f.InputDigit('1'))
+	require.Equal(t, "00118", f.InputDigit('8'))
+	require.Equal(t, "0011 81 ", f.InputDigit('1'))
+	require.Equal(t, "0011 81 3", f.InputDigit('3'))
+	require.Equal(t, "0011 81 33", f.InputDigit('3'))
+	require.Equal(t, "0011 81 33 3", f.InputDigit('3'))
+	require.Equal(t, "0011 81 3332", f.InputDigit('2'))
+	require.Equal(t, "0011 81 3332 2", f.InputDigit('2'))
+	require.Equal(t, "0011 81 3332 2 5", f.InputDigit('5'))
+	require.Equal(t, "0011 81 3332 2 56", f.InputDigit('6'))
+	require.Equal(t, "0011 81 3332 2 567", f.InputDigit('7'))
+	require.Equal(t, "0011 81 3332 2 5678", f.InputDigit('8'))
+
+	// 0011 244 250 253 222
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "00", f.InputDigit('0'))
+	require.Equal(t, "001", f.InputDigit('1'))
+	require.Equal(t, "0011", f.InputDigit('1'))
+	require.Equal(t, "00112", f.InputDigit('2'))
+	require.Equal(t, "001124", f.InputDigit('4'))
+	require.Equal(t, "0011 244 ", f.InputDigit('4'))
+	require.Equal(t, "0011 244 2", f.InputDigit('2'))
+	require.Equal(t, "0011 244 25", f.InputDigit('5'))
+	require.Equal(t, "0011 244 250", f.InputDigit('0'))
+	require.Equal(t, "0011 244 250 2", f.InputDigit('2'))
+	require.Equal(t, "0011 244 250 25", f.InputDigit('5'))
+	require.Equal(t, "0011 244 250 253", f.InputDigit('3'))
+	require.Equal(t, "0011 244 250 253 2", f.InputDigit('2'))
+	require.Equal(t, "0011 244 250 253 22", f.InputDigit('2'))
+	require.Equal(t, "0011 244 250 253 222", f.InputDigit('2'))
+}
+
+func TestAYTFLongIDD_KR(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.KR)
+	// 00300 1 650 253 2222
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "00", f.InputDigit('0'))
+	require.Equal(t, "003", f.InputDigit('3'))
+	require.Equal(t, "0030", f.InputDigit('0'))
+	require.Equal(t, "00300", f.InputDigit('0'))
+	require.Equal(t, "00300 1 ", f.InputDigit('1'))
+	require.Equal(t, "00300 1 6", f.InputDigit('6'))
+	require.Equal(t, "00300 1 65", f.InputDigit('5'))
+	require.Equal(t, "00300 1 650", f.InputDigit('0'))
+	require.Equal(t, "00300 1 650 2", f.InputDigit('2'))
+	require.Equal(t, "00300 1 650 25", f.InputDigit('5'))
+	require.Equal(t, "00300 1 650 253", f.InputDigit('3'))
+	require.Equal(t, "00300 1 650 253 2", f.InputDigit('2'))
+	require.Equal(t, "00300 1 650 253 22", f.InputDigit('2'))
+	require.Equal(t, "00300 1 650 253 222", f.InputDigit('2'))
+	require.Equal(t, "00300 1 650 253 2222", f.InputDigit('2'))
+}
+
+func TestAYTFLongNDD_KR(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.KR)
+	// 08811-9876-7890
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "08", f.InputDigit('8'))
+	require.Equal(t, "088", f.InputDigit('8'))
+	require.Equal(t, "0881", f.InputDigit('1'))
+	require.Equal(t, "08811", f.InputDigit('1'))
+	require.Equal(t, "08811-9", f.InputDigit('9'))
+	require.Equal(t, "08811-98", f.InputDigit('8'))
+	require.Equal(t, "08811-987", f.InputDigit('7'))
+	require.Equal(t, "08811-9876", f.InputDigit('6'))
+	require.Equal(t, "08811-9876-7", f.InputDigit('7'))
+	require.Equal(t, "08811-9876-78", f.InputDigit('8'))
+	require.Equal(t, "08811-9876-789", f.InputDigit('9'))
+	require.Equal(t, "08811-9876-7890", f.InputDigit('0'))
+
+	// 08500 11-9876-7890
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "08", f.InputDigit('8'))
+	require.Equal(t, "085", f.InputDigit('5'))
+	require.Equal(t, "0850", f.InputDigit('0'))
+	require.Equal(t, "08500 ", f.InputDigit('0'))
+	require.Equal(t, "08500 1", f.InputDigit('1'))
+	require.Equal(t, "08500 11", f.InputDigit('1'))
+	require.Equal(t, "08500 11-9", f.InputDigit('9'))
+	require.Equal(t, "08500 11-98", f.InputDigit('8'))
+	require.Equal(t, "08500 11-987", f.InputDigit('7'))
+	require.Equal(t, "08500 11-9876", f.InputDigit('6'))
+	require.Equal(t, "08500 11-9876-7", f.InputDigit('7'))
+	require.Equal(t, "08500 11-9876-78", f.InputDigit('8'))
+	require.Equal(t, "08500 11-9876-789", f.InputDigit('9'))
+	require.Equal(t, "08500 11-9876-7890", f.InputDigit('0'))
+}
+
+func TestAYTFLongNDD_SG(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.SG)
+	// 777777 9876 7890
+	require.Equal(t, "7", f.InputDigit('7'))
+	require.Equal(t, "77", f.InputDigit('7'))
+	require.Equal(t, "777", f.InputDigit('7'))
+	require.Equal(t, "7777", f.InputDigit('7'))
+	require.Equal(t, "77777", f.InputDigit('7'))
+	require.Equal(t, "777777 ", f.InputDigit('7'))
+	require.Equal(t, "777777 9", f.InputDigit('9'))
+	require.Equal(t, "777777 98", f.InputDigit('8'))
+	require.Equal(t, "777777 987", f.InputDigit('7'))
+	require.Equal(t, "777777 9876", f.InputDigit('6'))
+	require.Equal(t, "777777 9876 7", f.InputDigit('7'))
+	require.Equal(t, "777777 9876 78", f.InputDigit('8'))
+	require.Equal(t, "777777 9876 789", f.InputDigit('9'))
+	require.Equal(t, "777777 9876 7890", f.InputDigit('0'))
+}
+
+func TestAYTFShortNumberFormattingFix_AU(t *testing.T) {
+	useTestMetadata(t)
+	// For Australia, the national prefix is not optional when formatting.
+	f := GetAsYouTypeFormatter(regionCode.AU)
+
+	// 1234567890 - For leading digit 1, the national prefix formatting rule has first
+	// group only.
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "12", f.InputDigit('2'))
+	require.Equal(t, "123", f.InputDigit('3'))
+	require.Equal(t, "1234", f.InputDigit('4'))
+	require.Equal(t, "1234 5", f.InputDigit('5'))
+	require.Equal(t, "1234 56", f.InputDigit('6'))
+	require.Equal(t, "1234 567", f.InputDigit('7'))
+	require.Equal(t, "1234 567 8", f.InputDigit('8'))
+	require.Equal(t, "1234 567 89", f.InputDigit('9'))
+	require.Equal(t, "1234 567 890", f.InputDigit('0'))
+
+	// +61 1234 567 890 - Test the same number, but with the country code.
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+6", f.InputDigit('6'))
+	require.Equal(t, "+61 ", f.InputDigit('1'))
+	require.Equal(t, "+61 1", f.InputDigit('1'))
+	require.Equal(t, "+61 12", f.InputDigit('2'))
+	require.Equal(t, "+61 123", f.InputDigit('3'))
+	require.Equal(t, "+61 1234", f.InputDigit('4'))
+	require.Equal(t, "+61 1234 5", f.InputDigit('5'))
+	require.Equal(t, "+61 1234 56", f.InputDigit('6'))
+	require.Equal(t, "+61 1234 567", f.InputDigit('7'))
+	require.Equal(t, "+61 1234 567 8", f.InputDigit('8'))
+	require.Equal(t, "+61 1234 567 89", f.InputDigit('9'))
+	require.Equal(t, "+61 1234 567 890", f.InputDigit('0'))
+
+	// 212345678 - For leading digit 2, the national prefix formatting rule puts the
+	// national prefix before the first group.
+	f.Clear()
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "02", f.InputDigit('2'))
+	require.Equal(t, "021", f.InputDigit('1'))
+	require.Equal(t, "02 12", f.InputDigit('2'))
+	require.Equal(t, "02 123", f.InputDigit('3'))
+	require.Equal(t, "02 1234", f.InputDigit('4'))
+	require.Equal(t, "02 1234 5", f.InputDigit('5'))
+	require.Equal(t, "02 1234 56", f.InputDigit('6'))
+	require.Equal(t, "02 1234 567", f.InputDigit('7'))
+	require.Equal(t, "02 1234 5678", f.InputDigit('8'))
+
+	// 212345678 - Test the same number, but without the leading 0.
+	f.Clear()
+	require.Equal(t, "2", f.InputDigit('2'))
+	require.Equal(t, "21", f.InputDigit('1'))
+	require.Equal(t, "212", f.InputDigit('2'))
+	require.Equal(t, "2123", f.InputDigit('3'))
+	require.Equal(t, "21234", f.InputDigit('4'))
+	require.Equal(t, "212345", f.InputDigit('5'))
+	require.Equal(t, "2123456", f.InputDigit('6'))
+	require.Equal(t, "21234567", f.InputDigit('7'))
+	require.Equal(t, "212345678", f.InputDigit('8'))
+
+	// +61 2 1234 5678 - Test the same number, but with the country code.
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+6", f.InputDigit('6'))
+	require.Equal(t, "+61 ", f.InputDigit('1'))
+	require.Equal(t, "+61 2", f.InputDigit('2'))
+	require.Equal(t, "+61 21", f.InputDigit('1'))
+	require.Equal(t, "+61 2 12", f.InputDigit('2'))
+	require.Equal(t, "+61 2 123", f.InputDigit('3'))
+	require.Equal(t, "+61 2 1234", f.InputDigit('4'))
+	require.Equal(t, "+61 2 1234 5", f.InputDigit('5'))
+	require.Equal(t, "+61 2 1234 56", f.InputDigit('6'))
+	require.Equal(t, "+61 2 1234 567", f.InputDigit('7'))
+	require.Equal(t, "+61 2 1234 5678", f.InputDigit('8'))
+}
+
+func TestAYTFShortNumberFormattingFix_KR(t *testing.T) {
+	useTestMetadata(t)
+	// For Korea, the national prefix is not optional when formatting, and the national
+	// prefix formatting rule doesn't consist of only the first group.
+	f := GetAsYouTypeFormatter(regionCode.KR)
+
+	// 111
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "11", f.InputDigit('1'))
+	require.Equal(t, "111", f.InputDigit('1'))
+
+	// 114
+	f.Clear()
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "11", f.InputDigit('1'))
+	require.Equal(t, "114", f.InputDigit('4'))
+
+	// 13121234 - Test a mobile number without the national prefix. Even though it is
+	// not an emergency number, it should be formatted as a block.
+	f.Clear()
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "13", f.InputDigit('3'))
+	require.Equal(t, "131", f.InputDigit('1'))
+	require.Equal(t, "1312", f.InputDigit('2'))
+	require.Equal(t, "13121", f.InputDigit('1'))
+	require.Equal(t, "131212", f.InputDigit('2'))
+	require.Equal(t, "1312123", f.InputDigit('3'))
+	require.Equal(t, "13121234", f.InputDigit('4'))
+
+	// +82 131-2-1234 - Test the same number, but with the country code.
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+82 ", f.InputDigit('2'))
+	require.Equal(t, "+82 1", f.InputDigit('1'))
+	require.Equal(t, "+82 13", f.InputDigit('3'))
+	require.Equal(t, "+82 131", f.InputDigit('1'))
+	require.Equal(t, "+82 131-2", f.InputDigit('2'))
+	require.Equal(t, "+82 131-2-1", f.InputDigit('1'))
+	require.Equal(t, "+82 131-2-12", f.InputDigit('2'))
+	require.Equal(t, "+82 131-2-123", f.InputDigit('3'))
+	require.Equal(t, "+82 131-2-1234", f.InputDigit('4'))
+}
+
+func TestAYTFShortNumberFormattingFix_MX(t *testing.T) {
+	useTestMetadata(t)
+	// For Mexico, the national prefix is optional when formatting.
+	f := GetAsYouTypeFormatter(regionCode.MX)
+
+	// 911
+	require.Equal(t, "9", f.InputDigit('9'))
+	require.Equal(t, "91", f.InputDigit('1'))
+	require.Equal(t, "911", f.InputDigit('1'))
+
+	// 800 123 4567 - Test a toll-free number, which should have a formatting rule
+	// applied to it even though it doesn't begin with the national prefix.
+	f.Clear()
+	require.Equal(t, "8", f.InputDigit('8'))
+	require.Equal(t, "80", f.InputDigit('0'))
+	require.Equal(t, "800", f.InputDigit('0'))
+	require.Equal(t, "800 1", f.InputDigit('1'))
+	require.Equal(t, "800 12", f.InputDigit('2'))
+	require.Equal(t, "800 123", f.InputDigit('3'))
+	require.Equal(t, "800 123 4", f.InputDigit('4'))
+	require.Equal(t, "800 123 45", f.InputDigit('5'))
+	require.Equal(t, "800 123 456", f.InputDigit('6'))
+	require.Equal(t, "800 123 4567", f.InputDigit('7'))
+
+	// +52 800 123 4567 - Test the same number, but with the country code.
+	f.Clear()
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+5", f.InputDigit('5'))
+	require.Equal(t, "+52 ", f.InputDigit('2'))
+	require.Equal(t, "+52 8", f.InputDigit('8'))
+	require.Equal(t, "+52 80", f.InputDigit('0'))
+	require.Equal(t, "+52 800", f.InputDigit('0'))
+	require.Equal(t, "+52 800 1", f.InputDigit('1'))
+	require.Equal(t, "+52 800 12", f.InputDigit('2'))
+	require.Equal(t, "+52 800 123", f.InputDigit('3'))
+	require.Equal(t, "+52 800 123 4", f.InputDigit('4'))
+	require.Equal(t, "+52 800 123 45", f.InputDigit('5'))
+	require.Equal(t, "+52 800 123 456", f.InputDigit('6'))
+	require.Equal(t, "+52 800 123 4567", f.InputDigit('7'))
+}
+
+func TestAYTFNoNationalPrefix(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.IT)
+
+	require.Equal(t, "3", f.InputDigit('3'))
+	require.Equal(t, "33", f.InputDigit('3'))
+	require.Equal(t, "333", f.InputDigit('3'))
+	require.Equal(t, "333 3", f.InputDigit('3'))
+	require.Equal(t, "333 33", f.InputDigit('3'))
+	require.Equal(t, "333 333", f.InputDigit('3'))
+}
+
+func TestAYTFNoNationalPrefixFormattingRule(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.AO)
+
+	require.Equal(t, "3", f.InputDigit('3'))
+	require.Equal(t, "33", f.InputDigit('3'))
+	require.Equal(t, "333", f.InputDigit('3'))
+	require.Equal(t, "333 3", f.InputDigit('3'))
+	require.Equal(t, "333 33", f.InputDigit('3'))
+	require.Equal(t, "333 333", f.InputDigit('3'))
+}
+
+func TestAYTFShortNumberFormattingFix_US(t *testing.T) {
+	useTestMetadata(t)
+	// For the US, an initial 1 is treated specially.
+	f := GetAsYouTypeFormatter(regionCode.US)
+
+	// 101 - Test that the initial 1 is not treated as a national prefix.
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "10", f.InputDigit('0'))
+	require.Equal(t, "101", f.InputDigit('1'))
+
+	// 112 - Test that the initial 1 is not treated as a national prefix.
+	f.Clear()
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "11", f.InputDigit('1'))
+	require.Equal(t, "112", f.InputDigit('2'))
+
+	// 122 - Test that the initial 1 is treated as a national prefix.
+	f.Clear()
+	require.Equal(t, "1", f.InputDigit('1'))
+	require.Equal(t, "12", f.InputDigit('2'))
+	require.Equal(t, "1 22", f.InputDigit('2'))
+}
+
+func TestAYTFClearNDDAfterIDDExtraction(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.KR)
+
+	// Check that when we have successfully extracted an IDD, the previously extracted
+	// NDD is cleared since it is no longer valid.
+	require.Equal(t, "0", f.InputDigit('0'))
+	require.Equal(t, "00", f.InputDigit('0'))
+	require.Equal(t, "007", f.InputDigit('7'))
+	require.Equal(t, "0070", f.InputDigit('0'))
+	require.Equal(t, "00700", f.InputDigit('0'))
+	require.Equal(t, "0", f.getExtractedNationalPrefix())
+
+	// Once the IDD "00700" has been extracted, it no longer makes sense for the initial
+	// "0" to be treated as an NDD.
+	require.Equal(t, "00700 1 ", f.InputDigit('1'))
+	require.Equal(t, "", f.getExtractedNationalPrefix())
+
+	require.Equal(t, "00700 1 2", f.InputDigit('2'))
+	require.Equal(t, "00700 1 23", f.InputDigit('3'))
+	require.Equal(t, "00700 1 234", f.InputDigit('4'))
+	require.Equal(t, "00700 1 234 5", f.InputDigit('5'))
+	require.Equal(t, "00700 1 234 56", f.InputDigit('6'))
+	require.Equal(t, "00700 1 234 567", f.InputDigit('7'))
+	require.Equal(t, "00700 1 234 567 8", f.InputDigit('8'))
+	require.Equal(t, "00700 1 234 567 89", f.InputDigit('9'))
+	require.Equal(t, "00700 1 234 567 890", f.InputDigit('0'))
+	require.Equal(t, "00700 1 234 567 8901", f.InputDigit('1'))
+	require.Equal(t, "00700123456789012", f.InputDigit('2'))
+	require.Equal(t, "007001234567890123", f.InputDigit('3'))
+	require.Equal(t, "0070012345678901234", f.InputDigit('4'))
+	require.Equal(t, "00700123456789012345", f.InputDigit('5'))
+	require.Equal(t, "007001234567890123456", f.InputDigit('6'))
+	require.Equal(t, "0070012345678901234567", f.InputDigit('7'))
+}
+
+func TestAYTFNumberPatternsBecomingInvalidShouldNotResultInDigitLoss(t *testing.T) {
+	useTestMetadata(t)
+	f := GetAsYouTypeFormatter(regionCode.CN)
+
+	require.Equal(t, "+", f.InputDigit('+'))
+	require.Equal(t, "+8", f.InputDigit('8'))
+	require.Equal(t, "+86 ", f.InputDigit('6'))
+	require.Equal(t, "+86 9", f.InputDigit('9'))
+	require.Equal(t, "+86 98", f.InputDigit('8'))
+	require.Equal(t, "+86 988", f.InputDigit('8'))
+	require.Equal(t, "+86 988 1", f.InputDigit('1'))
+	// Now the number pattern is no longer valid because there are multiple leading
+	// digit patterns; when we try again to extract a country code we should ensure we
+	// use the last leading digit pattern, rather than the first one such that it
+	// *thinks* it's found a valid formatting rule again.
+	// https://github.com/google/libphonenumber/issues/437
+	require.Equal(t, "+8698812", f.InputDigit('2'))
+	require.Equal(t, "+86988123", f.InputDigit('3'))
+	require.Equal(t, "+869881234", f.InputDigit('4'))
+	require.Equal(t, "+8698812345", f.InputDigit('5'))
+}

--- a/docs/PORT_STATUS.md
+++ b/docs/PORT_STATUS.md
@@ -73,6 +73,29 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
 - `getExampleNumberForType` still has no region-less overload, so the
   every-type test uses a local helper (`getExampleNumberForTypeAnyRegion`).
 
+### AsYouTypeFormatterTest — ported
+- ✅ Faithful port in `asyoutypeformatter_test.go` (all 33 upstream test methods),
+  run against the synthetic test metadata via `useTestMetadata(t)`, reconciled
+  against v9.0.32. Covers invalid region / plus sign, the too-long multiple-leading-
+  digits case, national-prefix-with-space (incl. long NDD), per-region formatting
+  (US incl. full-width input, mobile short codes and vanity numbers; GB / NZ / DE /
+  AR / KR / MX / JP / AU / SG / IT / AO / CN), remembered-position tracking, long
+  IDD / NDD extraction, the short-number formatting fix, NANPA leading-1 handling,
+  and NDD-cleared-after-IDD-extraction.
+- New implementation in `asyoutypeformatter.go` (the `AsYouTypeFormatter` type and
+  the `GetAsYouTypeFormatter` constructor). It reuses the existing helpers
+  (`extractCountryCode`, `formattingRuleHasFirstGroupOnly`,
+  `normalizeDiallableCharsOnly`, region/country-code lookups, the `regexFor` cache,
+  the `arabicIndicNumberals` digit map). A few unexported `java.lang.StringBuilder`-
+  style methods were added to `stringbuilder.go` (`setLength`, `delete`,
+  `substring`, `lastIndexOf`, `charAt`); `formattingTemplate` is held as a `[]rune`
+  (not a `StringBuilder`) so the multi-byte `DIGIT_PLACEHOLDER` is indexed by
+  character the way Java indexes by UTF-16 char. Position tracking
+  (`GetRememberedPosition`) uses rune counts, which equal Java's UTF-16 char
+  positions for every (BMP) character a phone number can contain — supplementary
+  code points would differ, but phone input never contains them. The port required
+  no behaviour fixes; it passed the upstream assertions as written.
+
 ### Bugs the port surfaced and fixed
 - `extractPossibleNumber` never trimmed trailing junk: `UNWANTED_END_CHARS` was
   copied verbatim from Java (`[[\P{N}&&\P{L}]&&[^#]]+$`), but Go's RE2 engine has
@@ -112,11 +135,9 @@ upstream's `TestMetadataTestCase` + `RegionCode`), fixtures in
 
 ## Remaining work (roughly in order)
 
-1. **Implement `AsYouTypeFormatter`** (currently absent) and port
-   `AsYouTypeFormatterTest`.
-2. **Implement `PhoneNumberMatcher` / `findNumbers`** (currently a `nil` stub in
+1. **Implement `PhoneNumberMatcher` / `findNumbers`** (currently a `nil` stub in
    `phonenumbermatcher.go`) and port `PhoneNumberMatcherTest`.
-3. **Automate**: a scheduled task that detects new upstream releases, regenerates
+2. **Automate**: a scheduled task that detects new upstream releases, regenerates
    metadata, runs the (now-stable) synthetic tests, opens a PR for data-only
    deltas, and flags logic-touching changes for manual porting. See
    `docs/2.0-restructure.md`.

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2396,11 +2396,8 @@ func TruncateTooLongNumber(number *PhoneNumber) bool {
 	return true
 }
 
-// Gets an AsYouTypeFormatter for the specific region.
-// TODO(ttacon): uncomment once we do asyoutypeformatter.go
-// public AsYouTypeFormatter getAsYouTypeFormatter(String regionCode) {
-//    return new AsYouTypeFormatter(regionCode);
-// }
+// GetAsYouTypeFormatter (the analogue of Java's getAsYouTypeFormatter) is defined
+// alongside the AsYouTypeFormatter type in asyoutypeformatter.go.
 
 // Extracts country calling code from fullNumber, returns it and places
 // the remaining number in nationalNumber. It assumes that the leading plus

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -1,6 +1,7 @@
 package phonenumbers
 
 import (
+	"bytes"
 	"errors"
 	"slices"
 	"unicode/utf8"
@@ -106,4 +107,46 @@ func (b *StringBuilder) ResetWith(buf []byte) (int, error) {
 func (b *StringBuilder) ResetWithString(s string) (int, error) {
 	b.buf = append(b.buf[:0], s...)
 	return len(s), nil
+}
+
+// The methods below mirror the remaining java.lang.StringBuilder operations that
+// AsYouTypeFormatter relies on. They are deliberately unexported: unlike the
+// methods above (which back the public FormatWithBuf), these are only used
+// internally, so keeping them off the public surface avoids growing an API that
+// is already slated to become private (see the v2 notes in the README). Like
+// their Java counterparts they assume valid indices and will panic on
+// out-of-range access rather than returning an error.
+
+// charAt returns the byte at index i, mirroring StringBuilder.charAt. Callers in
+// the port only ever index ASCII content, so a byte is an exact analogue of
+// Java's char here.
+func (b *StringBuilder) charAt(i int) byte { return b.buf[i] }
+
+// setLength truncates the buffer to n bytes, or pads it with NUL bytes if n is
+// greater than the current length, mirroring StringBuilder.setLength.
+func (b *StringBuilder) setLength(n int) {
+	if n <= len(b.buf) {
+		b.buf = b.buf[:n]
+		return
+	}
+	for len(b.buf) < n {
+		b.buf = append(b.buf, 0)
+	}
+}
+
+// delete removes the bytes in [start, end), mirroring StringBuilder.delete.
+func (b *StringBuilder) delete(start, end int) {
+	b.buf = append(b.buf[:start], b.buf[end:]...)
+}
+
+// substring returns the bytes in [start, end) as a string, mirroring
+// StringBuilder.substring(start, end).
+func (b *StringBuilder) substring(start, end int) string {
+	return string(b.buf[start:end])
+}
+
+// lastIndexOf returns the byte index of the last occurrence of s, or -1 if
+// absent, mirroring StringBuilder.lastIndexOf.
+func (b *StringBuilder) lastIndexOf(s string) int {
+	return bytes.LastIndex(b.buf, []byte(s))
 }


### PR DESCRIPTION
## What

Implements `AsYouTypeFormatter` — the part of libphonenumber that formats a phone number incrementally as each digit is entered (the behaviour behind a phone-entry field, turning `6502530000` into `650 253 0000` keystroke by keystroke). This was the last major piece of libphonenumber's public API still missing from the port; only a commented-out stub existed in `phonenumberutil.go`.

## Why

Per the test-port roadmap in `docs/PORT_STATUS.md`, `AsYouTypeFormatter` was the #1 remaining item. As with every prior port, the goal is to track the **Java** reference implementation as closely as Go allows so type/method names and tests mirror upstream and stay easy to verify.

## Changes

- **`asyoutypeformatter.go`** (new) — a faithful, near line-for-line translation of upstream `AsYouTypeFormatter.java` (v9.0.31), plus the exported `GetAsYouTypeFormatter` constructor (the analogue of Java's `getAsYouTypeFormatter`). Reuses existing helpers: `extractCountryCode`, `formattingRuleHasFirstGroupOnly`, `normalizeDiallableCharsOnly`, region/country-code lookups, the `regexFor` cache, and the `arabicIndicNumberals` digit map (which already covers full-width digits).
- **`asyoutypeformatter_test.go`** (new) — faithful port of all 33 `AsYouTypeFormatterTest` methods, run against the synthetic test metadata via `useTestMetadata(t)`. They pass as written; **the port required no behaviour fixes**.
- **`stringbuilder.go`** — adds five unexported `java.lang.StringBuilder`-style helpers (`setLength`, `delete`, `substring`, `lastIndexOf`, `charAt`). Kept internal so the public surface (already slated to shrink in v2) doesn't grow.
- **`phonenumberutil.go`** — removes the stale `// TODO: uncomment once we do asyoutypeformatter.go` stub.
- **`docs/PORT_STATUS.md`** — moves AYTF to a ported section; `PhoneNumberMatcher` is now the #1 remaining item.

## Reviewer notes

A couple of Go-vs-Java translation points worth a look (both commented in-code):

- **`formattingTemplate` is a `[]rune`, not a `StringBuilder`.** The `DIGIT_PLACEHOLDER` (`U+2008`) is multi-byte in UTF-8, and the template is indexed by character. Rune indices match Java's UTF-16 char indices for every BMP character a phone number can contain.
- **`inputDigitHelper`** replaces Java's stateful `Matcher.find(pos)`/`replaceFirst` with a direct rune scan for the next placeholder — identical behaviour, no regex.
- **`GetRememberedPosition`** tracks positions as rune counts, equal to Java's UTF-16 char positions for all BMP input. Supplementary code points would differ, but phone input never contains them.

## Verification

`go build ./...`, the 33 ported tests, full suite, `go test -race`, `go vet ./...`, and `gofmt -l` are all clean.