### PR TITLE
Add sync-upstream skill and make the sync map mechanical

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: sync-upstream
+description: Sync this Go port with a new upstream google/libphonenumber release — regenerate the embedded metadata and reconcile the ported Java logic. Use when the user says "sync with upstream", "do an upstream sync", "reconcile against libphonenumber", "pull the latest libphonenumber", bump to a new libphonenumber version, or invokes /sync-upstream. SYNC.md holds the state (baseline version + deliberate divergences); this skill is the procedure.
+---
+
+# Sync with upstream libphonenumber
+
+This package is a Go port of [google/libphonenumber](https://github.com/google/libphonenumber),
+tracking its **Java** reference implementation. A sync is **two independent operations** —
+do them in order, but understand they're different in kind:
+
+1. **Metadata regen** — *mechanical.* Rebuild the embedded `data/` blobs from a new upstream
+   release. Fully automated by `cmd/buildmetadata`.
+2. **Code reconciliation** — *judgment.* Port new Java *logic* changes into the Go files. Can't
+   be automated; this is the real reason [SYNC.md](../../../SYNC.md) exists.
+
+State lives in [SYNC.md](../../../SYNC.md): the **code baseline** (`Code reconciled against vX.Y.Z`)
+and the **deliberate divergences** (what we intentionally do *not* port). Read it first. The
+embedded-metadata version is tracked separately in the generated `metadata/version.go`
+(`metadata.Version`) — never hand-edit that.
+
+Run everything from the repo root (`/Users/rowan/nyaruka/phonenumbers`).
+
+---
+
+## Phase 1 — Metadata regen (mechanical)
+
+```sh
+go run ./cmd/buildmetadata            # latest upstream release
+# go run ./cmd/buildmetadata v9.0.32  # or pin a specific tag
+```
+
+This resolves the target tag, wipes and re-clones upstream into `_build/` (a shallow
+`--depth=1` checkout **at the target tag** — gitignored), rebuilds every embedded blob
+(`data/`, `metadata/data/`, `carrier/data/`, `geocoding/data/`, `timezone/data/`), and
+rewrites the generated `metadata/version.go` with the tag it built from.
+
+Then:
+
+```sh
+go test ./...
+```
+
+Review the diff in `data/`, `metadata/data/`, the per-package `*/data/` blobs, and
+`metadata/version.go`. A metadata-only release (no Java logic change) can stop here — but
+still finish with the **Finalize** step so the sync log records it.
+
+> The target tag you built becomes the new code baseline once Phase 2 reconciles against it.
+
+---
+
+## Phase 2 — Code reconciliation (judgment)
+
+Goal: apply any upstream Java *logic* changes between the **old baseline** (SYNC.md) and the
+**target** (the tag Phase 1 built) to each Go port.
+
+### Get both tags side by side for diffing
+
+Phase 1 left `_build/` as a shallow clone at the **target** tag. Fetch the **baseline** tag
+into it so you can diff tree-to-tree (no merge base needed — `git diff A B` compares trees):
+
+```sh
+BASE=v9.0.31      # from SYNC.md "Code reconciled against"
+TARGET=v9.0.32    # the tag Phase 1 built (see metadata/version.go)
+git -C _build fetch --depth=1 origin tag "$BASE"
+```
+
+### Diff each ported source, baseline→target
+
+The per-file headers are the source of truth for the Go→Java mapping — every reconcilable
+file carries a `// Port of <upstream/path> from google/libphonenumber.` header. Enumerate them:
+
+```sh
+grep -rn "Port of" --include='*.go' . | grep -v _test.go | grep -v _build/
+```
+
+For each upstream path `P`, diff it across the window and reconcile anything non-trivial:
+
+```sh
+git -C _build diff "$BASE" "$TARGET" -- "$P"
+```
+
+The mapping (kept current; **if files move, the headers win** and this table is refreshed):
+
+| Go | upstream Java path |
+|---|---|
+| `phonenumberutil.go`, `enums.go` | `java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java` |
+| `asyoutypeformatter.go` | `java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java` |
+| `shortnumberinfo.go` | `java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java` |
+| `phonenumbermatcher.go` | `java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java` |
+| `phonenumbermatch.go` | `java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatch.java` |
+| `errors.go` | `java/libphonenumber/src/com/google/i18n/phonenumbers/NumberParseException.java` |
+| `internal/regexcache/` | `java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexCache.java` |
+| `internal/regexbasedmatcher/` | `java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexBasedMatcher.java`, `.../internal/MatcherApi.java` |
+| `metadata/source.go`, `alternateformats.go` | `java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/*`, `.../MetadataLoader.java` |
+| `carrier/` | `java/carrier/src/com/google/i18n/phonenumbers/PhoneNumberToCarrierMapper.java` |
+| `geocoding/` | `java/geocoder/src/com/google/i18n/phonenumbers/geocoding/PhoneNumberOfflineGeocoder.java` |
+| `timezone/` | `java/geocoder/src/com/google/i18n/phonenumbers/PhoneNumberToTimeZonesMapper.java` |
+| `internal/prefixmapper/` | `java/internal/prefixmapper/src/com/google/i18n/phonenumbers/prefixmapper/*` |
+| `internal/metadatabuilder/` | `tools/java/common/src/com/google/i18n/phonenumbers/BuildMetadataFromXml.java` |
+
+`internal/serialize` and `internal/stringbuilder` are Go-specific scaffolding (gzip/binary
+decode; a `java.lang.StringBuilder` stand-in) with no upstream logic to reconcile — skip them.
+
+The corresponding **upstream tests** move in lockstep. The Go tests mirror the Java test
+classes (e.g. `PhoneNumberUtilTest` → `phonenumberutil_test.go` and friends); diff those too
+and port new cases:
+
+```sh
+git -C _build diff "$BASE" "$TARGET" -- "$(echo "$P" | sed 's#/src/#/test/#')"
+```
+
+### Reconcile
+
+For each non-empty diff, translate the relevant change into the Go port. While doing so:
+
+- **Preserve upstream source order.** The headers promise functions/methods are kept in
+  upstream order to ease the *next* sync — keep it that way.
+- **Honor deliberate divergences.** Check SYNC.md before porting something back; some upstream
+  code is intentionally absent (e.g. Mockito-style metadata-source injection tests, Java
+  iterator semantics with no Go equivalent). Don't re-introduce it. If you make a *new*
+  intentional divergence, record it.
+- **Keep it a port, not an enhancement.** Match libphonenumber's behaviour; don't add API.
+- **Don't hand-edit generated files** (`metadata/version.go`, `*.pb.go`) or the `data/` blobs —
+  those come from Phase 1 / protoc.
+
+Then make it green:
+
+```sh
+go test ./...
+```
+
+---
+
+## Finalize
+
+Update [SYNC.md](../../../SYNC.md) (state only):
+
+1. Bump **`Code reconciled against`** in the Baseline section to the target tag.
+2. Add a **Sync log** entry (newest first): what was reconciled or pulled, and the version.
+3. If anything new was intentionally left unported, add it under **Deliberate divergences**.
+
+Do **not** touch `CHANGELOG.md` — it's maintained by the release process.
+
+Leave public-facing text (commit messages, comments) describing the software in general terms.

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -114,8 +114,11 @@ git -C _build diff "$BASE" "$TARGET" -- "$(echo "$P" | sed 's#/src/#/test/#')"
 
 For each non-empty diff, translate the relevant change into the Go port. While doing so:
 
-- **Preserve upstream source order.** The headers promise functions/methods are kept in
-  upstream order to ease the *next* sync — keep it that way.
+- **Preserve upstream source order.** The core ports keep their functions/methods in the same
+  order as the upstream Java so the *next* sync's diff lines up — maintain that as you reconcile.
+  A few files are deliberately reorganized for Go idiom and don't follow upstream order
+  (`metadata/source.go`, `internal/regexcache`, `internal/regexbasedmatcher`,
+  `internal/prefixmapper`); that's expected.
 - **Honor deliberate divergences.** Check SYNC.md before porting something back; some upstream
   code is intentionally absent (e.g. Mockito-style metadata-source injection tests, Java
   iterator semantics with no Go equivalent). Don't re-introduce it. If you make a *new*

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -68,7 +68,7 @@ git -C _build fetch --depth=1 origin tag "$BASE"
 ### Diff each ported source, baseline→target
 
 The per-file headers are the source of truth for the Go→Java mapping — every reconcilable
-file carries a `// Port of <upstream/path> from google/libphonenumber.` header. Enumerate them:
+file carries a `// Port of <upstream/path>.` header. Enumerate them:
 
 ```sh
 grep -rn "Port of" --include='*.go' . | grep -v _test.go | grep -v _build/
@@ -137,9 +137,10 @@ go test ./...
 Update [SYNC.md](../../../SYNC.md) (state only):
 
 1. Bump **`Code reconciled against`** in the Baseline section to the target tag.
-2. Add a **Sync log** entry (newest first): what was reconciled or pulled, and the version.
-3. If anything new was intentionally left unported, add it under **Deliberate divergences**.
+2. If anything new was intentionally left unported, add it under **Deliberate divergences**.
 
-Do **not** touch `CHANGELOG.md` — it's maintained by the release process.
+Record what was reconciled (and the version) in the commit / PR message — git history is the
+sync log, so SYNC.md doesn't keep one. Don't touch `CHANGELOG.md` either; it's maintained by
+the release process.
 
 Leave public-facing text (commit messages, comments) describing the software in general terms.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ To rebuild from a specific release instead, pass the tag:
 
 After syncing, run the tests and update [SYNC.md](SYNC.md) — which records the upstream
 version the port is reconciled against and the deliberate divergences from upstream.
+
+Regenerating the metadata is only half of a sync; the ported Go code also has to be
+reconciled against the new release's Java changes. If you use [Claude Code](https://claude.com/claude-code),
+the **`sync-upstream`** skill ([`.claude/skills/sync-upstream/SKILL.md`](.claude/skills/sync-upstream/SKILL.md))
+walks through the whole process — metadata regen plus the per-file code reconciliation — and
+updates [SYNC.md](SYNC.md) at the end. Invoke it with `/sync-upstream` or by asking it to
+sync with upstream.

--- a/SYNC.md
+++ b/SYNC.md
@@ -29,18 +29,3 @@ Places where this port intentionally differs from upstream:
   `testGetMetadataForRegionForMissingMetadata` and its non-geographical variant (both rely on
   Mockito-style metadata-source injection), and `testRemovalNotSupported` (Go's range-over-func
   iterator has no `remove()`).
-
-## Sync log
-
-Newest first. Each entry: what was reconciled or pulled, and the upstream version.
-
-- **2026-06-03** — Moved the sync *procedure* into the `sync-upstream` skill; SYNC.md is now
-  pure state. Per-file `// Port of` headers upgraded to full upstream paths so reconciliation
-  diffs are mechanical.
-- **2026-06-02** — Established this file; moved per-file version headers here.
-  `cmd/buildmetadata` now resolves the latest upstream release tag itself (pass a tag to
-  pin a specific release) and records it in the generated `metadata/version.go`, so the
-  embedded metadata's version is no longer hand-maintained here. `go test ./...` green.
-- **2026-06-01** (v1.8.0) — Regenerated all metadata against `v9.0.31`; refactored to
-  ease upstream syncing.
-- Ported `PhoneNumberMatcher` + `PhoneNumberMatch` and their tests against `v9.0.31`.

--- a/SYNC.md
+++ b/SYNC.md
@@ -1,49 +1,42 @@
 # Upstream Sync
 
 This package is a port of Google's [libphonenumber](https://github.com/google/libphonenumber),
-tracking its **Java** reference implementation. This file is the source of truth for
-*which upstream version each part is reconciled against* and *what we deliberately
-diverge on*.
+tracking its **Java** reference implementation. This file is the **state** of the sync:
+*which upstream version the code is reconciled against* and *what we deliberately diverge on*.
 
-Per-file headers only record which Java source a file maps to (e.g. `// Port of
-PhoneNumberUtil.java ...`); the upstream version lives here so it isn't duplicated
-across the tree and can't go stale file-by-file.
+The **procedure** for performing a sync lives in the `sync-upstream` skill
+([`.claude/skills/sync-upstream/SKILL.md`](.claude/skills/sync-upstream/SKILL.md)) — run it
+with "sync with upstream" or `/sync-upstream`.
+
+Per-file headers carry the Go→Java mapping: each ported file records the full upstream path it
+maps to (e.g. `// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java`).
+The reconciled version isn't duplicated into those headers — it lives here, so it can't go stale
+file-by-file.
 
 ## Baseline
 
 - **Code reconciled against:** `v9.0.31`
 
-The **metadata** version isn't tracked here — `cmd/buildmetadata` records the upstream
-release it built `data/` from in the generated
-[`metadata/version.go`](metadata/version.go) (the `metadata.Version` constant).
-
-## Building metadata
-
-`cmd/buildmetadata` regenerates the embedded `data/` from upstream libphonenumber:
-
-1. `go run ./cmd/buildmetadata` — resolves the **latest** libphonenumber release tag,
-   clones it, rebuilds `data/`, and records the tag in the generated
-   [`metadata/version.go`](metadata/version.go). To rebuild from a specific release
-   instead (e.g. to reproduce older embedded data), pass the tag:
-   `go run ./cmd/buildmetadata v9.0.31`.
-2. `go test ./...` and fix any reconciliation differences.
-3. Review the `data/`, `metadata/data/` and `metadata/version.go` diff. Reconciling the *code* against the
-   new release is a human judgment, so it isn't automated: bump **Code reconciled
-   against** in **Baseline** above and add a **Sync log** entry.
+The **metadata** version isn't tracked here — `cmd/buildmetadata` records the upstream release it
+built `data/` from in the generated [`metadata/version.go`](metadata/version.go) (the
+`metadata.Version` constant).
 
 ## Deliberate divergences
 
 Places where this port intentionally differs from upstream:
 
-- **Unported upstream tests** — three `PhoneNumberUtilTest` cases have no Go
-  counterpart: `testGetMetadataForRegionForMissingMetadata` and its non-geographical
-  variant (both rely on Mockito-style metadata-source injection), and
-  `testRemovalNotSupported` (Go's range-over-func iterator has no `remove()`).
+- **Unported upstream tests** — three `PhoneNumberUtilTest` cases have no Go counterpart:
+  `testGetMetadataForRegionForMissingMetadata` and its non-geographical variant (both rely on
+  Mockito-style metadata-source injection), and `testRemovalNotSupported` (Go's range-over-func
+  iterator has no `remove()`).
 
 ## Sync log
 
 Newest first. Each entry: what was reconciled or pulled, and the upstream version.
 
+- **2026-06-03** — Moved the sync *procedure* into the `sync-upstream` skill; SYNC.md is now
+  pure state. Per-file `// Port of` headers upgraded to full upstream paths so reconciliation
+  diffs are mechanical.
 - **2026-06-02** — Established this file; moved per-file version headers here.
   `cmd/buildmetadata` now resolves the latest upstream release tag itself (pass a tag to
   pin a specific release) and records it in the generated `metadata/version.go`, so the

--- a/alternateformats.go
+++ b/alternateformats.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/* alternate-formats loading.
-// Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 
 import (

--- a/alternateformats.go
+++ b/alternateformats.go
@@ -1,4 +1,4 @@
-// Port of metadata/source/* alternate-formats loading from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/* alternate-formats loading from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/alternateformats.go
+++ b/alternateformats.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/* alternate-formats loading from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/* alternate-formats loading.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/asyoutypeformatter.go
+++ b/asyoutypeformatter.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java.
-// Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 
 import (

--- a/asyoutypeformatter.go
+++ b/asyoutypeformatter.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/asyoutypeformatter.go
+++ b/asyoutypeformatter.go
@@ -1,4 +1,4 @@
-// Port of AsYouTypeFormatter.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -1,4 +1,4 @@
-// Port of carrier/PhoneNumberToCarrierMapper.java from google/libphonenumber.
+// Port of java/carrier/src/com/google/i18n/phonenumbers/PhoneNumberToCarrierMapper.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package carrier
 

--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -1,4 +1,4 @@
-// Port of java/carrier/src/com/google/i18n/phonenumbers/PhoneNumberToCarrierMapper.java from google/libphonenumber.
+// Port of java/carrier/src/com/google/i18n/phonenumbers/PhoneNumberToCarrierMapper.java.
 // Functions are kept in upstream source order to ease syncing.
 package carrier
 

--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -1,5 +1,4 @@
 // Port of java/carrier/src/com/google/i18n/phonenumbers/PhoneNumberToCarrierMapper.java.
-// Functions are kept in upstream source order to ease syncing.
 package carrier
 
 import (

--- a/enums.go
+++ b/enums.go
@@ -1,4 +1,4 @@
-// Port of PhoneNumberUtil.java (enums) from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java (enums) from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/enums.go
+++ b/enums.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java (enums).
-// Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 
 // INTERNATIONAL and NATIONAL formats are consistent with the definition

--- a/enums.go
+++ b/enums.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java (enums) from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java (enums).
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/NumberParseException.java (+ package errors) from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/NumberParseException.java (+ package errors).
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/NumberParseException.java (+ package errors).
-// Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 
 import (

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-// Port of NumberParseException.java + package errors from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/NumberParseException.java (+ package errors) from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/geocoding/geocoding.go
+++ b/geocoding/geocoding.go
@@ -1,4 +1,4 @@
-// Port of java/geocoder/src/com/google/i18n/phonenumbers/geocoding/PhoneNumberOfflineGeocoder.java from google/libphonenumber.
+// Port of java/geocoder/src/com/google/i18n/phonenumbers/geocoding/PhoneNumberOfflineGeocoder.java.
 // Functions are kept in upstream source order to ease syncing.
 package geocoding
 

--- a/geocoding/geocoding.go
+++ b/geocoding/geocoding.go
@@ -1,4 +1,4 @@
-// Port of geocoder/geocoding/PhoneNumberOfflineGeocoder.java from google/libphonenumber.
+// Port of java/geocoder/src/com/google/i18n/phonenumbers/geocoding/PhoneNumberOfflineGeocoder.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package geocoding
 

--- a/geocoding/geocoding.go
+++ b/geocoding/geocoding.go
@@ -1,5 +1,4 @@
 // Port of java/geocoder/src/com/google/i18n/phonenumbers/geocoding/PhoneNumberOfflineGeocoder.java.
-// Functions are kept in upstream source order to ease syncing.
 package geocoding
 
 import (

--- a/internal/metadatabuilder/metadatabuilder.go
+++ b/internal/metadatabuilder/metadatabuilder.go
@@ -1,4 +1,4 @@
-// Port of tools/java/common/src/com/google/i18n/phonenumbers/BuildMetadataFromXml.java from google/libphonenumber.
+// Port of tools/java/common/src/com/google/i18n/phonenumbers/BuildMetadataFromXml.java.
 // Functions are kept in upstream source order to ease syncing.
 //
 // This is build-time-only machinery: it compiles upstream's metadata XML into

--- a/internal/metadatabuilder/metadatabuilder.go
+++ b/internal/metadatabuilder/metadatabuilder.go
@@ -1,4 +1,4 @@
-// Port of tools/.../BuildMetadataFromXml.java from google/libphonenumber.
+// Port of tools/java/common/src/com/google/i18n/phonenumbers/BuildMetadataFromXml.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 //
 // This is build-time-only machinery: it compiles upstream's metadata XML into

--- a/internal/metadatabuilder/metadatabuilder.go
+++ b/internal/metadatabuilder/metadatabuilder.go
@@ -1,5 +1,4 @@
 // Port of tools/java/common/src/com/google/i18n/phonenumbers/BuildMetadataFromXml.java.
-// Functions are kept in upstream source order to ease syncing.
 //
 // This is build-time-only machinery: it compiles upstream's metadata XML into
 // the proto types that cmd/buildmetadata serializes into the embedded data. It

--- a/internal/prefixmapper/prefixmapper.go
+++ b/internal/prefixmapper/prefixmapper.go
@@ -1,4 +1,4 @@
-// Port of java/internal/prefixmapper/src/com/google/i18n/phonenumbers/prefixmapper/* (shared prefix lookup) from google/libphonenumber.
+// Port of java/internal/prefixmapper/src/com/google/i18n/phonenumbers/prefixmapper/* (shared prefix lookup).
 //
 // A Mapper resolves the value (carrier name, geocoding description, …) mapped to
 // the longest matching numeric prefix of an E164 number. It is shared by the

--- a/internal/prefixmapper/prefixmapper.go
+++ b/internal/prefixmapper/prefixmapper.go
@@ -1,4 +1,4 @@
-// Port of internal/prefixmapper/* (shared prefix lookup) from google/libphonenumber.
+// Port of java/internal/prefixmapper/src/com/google/i18n/phonenumbers/prefixmapper/* (shared prefix lookup) from google/libphonenumber.
 //
 // A Mapper resolves the value (carrier name, geocoding description, …) mapped to
 // the longest matching numeric prefix of an E164 number. It is shared by the

--- a/internal/regexbasedmatcher/regexbasedmatcher.go
+++ b/internal/regexbasedmatcher/regexbasedmatcher.go
@@ -1,6 +1,7 @@
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexBasedMatcher.java + .../internal/MatcherApi.java from google/libphonenumber.
+
 // Package regexbasedmatcher matches national numbers against the patterns in
-// phone-number metadata, mirroring upstream's internal/RegexBasedMatcher and
-// MatcherApi.
+// phone-number metadata.
 package regexbasedmatcher
 
 import (

--- a/internal/regexbasedmatcher/regexbasedmatcher.go
+++ b/internal/regexbasedmatcher/regexbasedmatcher.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexBasedMatcher.java + .../internal/MatcherApi.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexBasedMatcher.java + .../internal/MatcherApi.java.
 
 // Package regexbasedmatcher matches national numbers against the patterns in
 // phone-number metadata.

--- a/internal/regexcache/regexcache.go
+++ b/internal/regexcache/regexcache.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexCache.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexCache.java.
 
 // Package regexcache caches compiled regular expressions keyed by their pattern
 // string, so the libphonenumber port avoids recompiling the same

--- a/internal/regexcache/regexcache.go
+++ b/internal/regexcache/regexcache.go
@@ -1,7 +1,8 @@
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/internal/RegexCache.java from google/libphonenumber.
+
 // Package regexcache caches compiled regular expressions keyed by their pattern
 // string, so the libphonenumber port avoids recompiling the same
-// metadata-derived patterns on every call. It mirrors upstream's
-// internal/RegexCache.
+// metadata-derived patterns on every call.
 package regexcache
 
 import (

--- a/metadata/source.go
+++ b/metadata/source.go
@@ -1,4 +1,4 @@
-// Port of metadata/source/* + MetadataLoader from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/* + .../MetadataLoader.java from google/libphonenumber.
 package metadata
 
 import (

--- a/metadata/source.go
+++ b/metadata/source.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/* + .../MetadataLoader.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/metadata/source/* + .../MetadataLoader.java.
 package metadata
 
 import (

--- a/phonenumbermatch.go
+++ b/phonenumbermatch.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatch.java.
-// Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 
 import "fmt"

--- a/phonenumbermatch.go
+++ b/phonenumbermatch.go
@@ -1,4 +1,4 @@
-// Port of PhoneNumberMatch.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatch.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/phonenumbermatch.go
+++ b/phonenumbermatch.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatch.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatch.java.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/phonenumbermatcher.go
+++ b/phonenumbermatcher.go
@@ -1,4 +1,4 @@
-// Port of PhoneNumberMatcher.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java from google/libphonenumber.
 // Methods are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/phonenumbermatcher.go
+++ b/phonenumbermatcher.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java.
-// Methods are kept in upstream source order to ease syncing.
 package phonenumbers
 
 import (

--- a/phonenumbermatcher.go
+++ b/phonenumbermatcher.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatcher.java.
 // Methods are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java.
-// Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 
 import (

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -1,4 +1,4 @@
-// Port of PhoneNumberUtil.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/shortnumberinfo.go
+++ b/shortnumberinfo.go
@@ -1,4 +1,4 @@
-// Port of ShortNumberInfo.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/shortnumberinfo.go
+++ b/shortnumberinfo.go
@@ -1,4 +1,4 @@
-// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java from google/libphonenumber.
+// Port of java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java.
 // Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 

--- a/shortnumberinfo.go
+++ b/shortnumberinfo.go
@@ -1,5 +1,4 @@
 // Port of java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java.
-// Functions are kept in upstream source order to ease syncing.
 package phonenumbers
 
 import (

--- a/timezone/timezone.go
+++ b/timezone/timezone.go
@@ -1,4 +1,4 @@
-// Port of java/geocoder/src/com/google/i18n/phonenumbers/PhoneNumberToTimeZonesMapper.java from google/libphonenumber.
+// Port of java/geocoder/src/com/google/i18n/phonenumbers/PhoneNumberToTimeZonesMapper.java.
 // Functions are kept in upstream source order to ease syncing.
 package timezone
 

--- a/timezone/timezone.go
+++ b/timezone/timezone.go
@@ -1,4 +1,4 @@
-// Port of geocoder/PhoneNumberToTimeZonesMapper.java from google/libphonenumber.
+// Port of java/geocoder/src/com/google/i18n/phonenumbers/PhoneNumberToTimeZonesMapper.java from google/libphonenumber.
 // Functions are kept in upstream source order to ease syncing.
 package timezone
 

--- a/timezone/timezone.go
+++ b/timezone/timezone.go
@@ -1,5 +1,4 @@
 // Port of java/geocoder/src/com/google/i18n/phonenumbers/PhoneNumberToTimeZonesMapper.java.
-// Functions are kept in upstream source order to ease syncing.
 package timezone
 
 import (


### PR DESCRIPTION
## What

Reworks how syncing this port with upstream libphonenumber is documented and driven.

A "sync" is really **two operations** that this change now separates cleanly:

1. **Metadata regen** — mechanical; `cmd/buildmetadata` rebuilds the embedded `data/` from a release and records the version in generated `metadata/version.go`.
2. **Code reconciliation** — judgment; the ported Go logic has to be reconciled against the new release's Java changes.

### Changes

- **New `sync-upstream` skill** (`.claude/skills/sync-upstream/SKILL.md`) encoding the full two-phase procedure: metadata regen, then per-file reconciliation that diffs each ported Java source between the reconciled baseline and the target release (`git -C _build diff $BASE $TARGET -- <path>`), honoring the deliberate divergences, then finalizing SYNC.md.
- **SYNC.md slimmed to pure state** — code baseline, deliberate divergences, and sync log. The step-by-step "how" moved into the skill, which SYNC.md now points to. "Read SYNC.md and do a sync" still works as a fallback.
- **File headers carry full upstream paths** — every `// Port of` header now records the full repo-relative Java path (e.g. `java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java`), so the reconciliation set is `grep`-enumerable and each entry is directly diffable. The two `internal/regex*` packages got a matching greppable header too.
- **README** notes the skill in its metadata section.

## Why

The previous setup mixed procedure and state in SYNC.md and left headers with bare class names, so a sync meant re-deriving the steps and hunting for each upstream source. Splitting stable *procedure* (skill) from per-sync *state* (SYNC.md), with headers as the mechanical Go→Java map, makes a sync repeatable and the file-to-source mapping unambiguous.

## Notes for reviewer

- No functional change — comments/headers and docs only.
- `go build`, `go vet`, and `go test ./...` all pass.
- Every path written into a header was verified to resolve in an upstream `v9.0.31` checkout.
- `internal/serialize` and `internal/stringbuilder` are intentionally excluded (Go-specific scaffolding, no upstream logic). `metadata/metadata_util.go` was also left without a `// Port of` marker for now — flagged in discussion as a possible follow-up.