### PR TITLE
Align public API with Java: export methods and port missing overloads

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -132,6 +132,15 @@ For each non-empty diff, translate the relevant change into the Go port. While d
   iterator semantics with no Go equivalent). Don't re-introduce it. If you make a *new*
   intentional divergence, record it.
 - **Keep it a port, not an enhancement.** Match libphonenumber's behaviour; don't add API.
+- **Java overloads → distinct Go names.** Go can't overload, so a set of Java methods sharing a
+  name maps to several Go funcs: give one the bare PascalCase name and suffix the rest with the
+  parameter(s) that distinguish them. Follow the established pattern — `Parse`/`ParseToNumber`,
+  `IsNumberMatch`/`IsNumberMatchWithNumbers`/`IsNumberMatchWithOneNumber`,
+  `GetExampleNumberForType`/`GetExampleNumberForTypeInRegion`,
+  `IsPossibleNumber`/`IsPossibleNumberFromRegion`, `IsNumberGeographical`/`IsNumberGeographicalForType`.
+  Porting an overload that *already exists* upstream is faithful porting, not the "don't add API"
+  case above — fill the gap rather than skipping it. Which overload keeps the bare name (and the
+  exact suffix) is a judgment call; flag new public names in the PR.
 - **Don't hand-edit generated files** (`metadata/version.go`, `*.pb.go`) or the `data/` blobs —
   those come from Phase 1 / protoc.
 

--- a/asyoutypeformatter.go
+++ b/asyoutypeformatter.go
@@ -445,7 +445,7 @@ func (aytf *AsYouTypeFormatter) attemptToFormatAccruedDigits() string {
 			// retain all the number entered and not change in order to match a format (of same
 			// leading digits and length) display in that way.
 			fullOutput := aytf.appendNationalNumber(formattedNumber)
-			formattedNumberDigitsOnly := normalizeDiallableCharsOnly(fullOutput)
+			formattedNumberDigitsOnly := NormalizeDiallableCharsOnly(fullOutput)
 			if formattedNumberDigitsOnly == aytf.accruedInputWithoutFormatting.String() {
 				// If it's the same (i.e entered number and format is same), then it's safe to
 				// return this in formatted number as nothing is lost / added.

--- a/examplenumbers_test.go
+++ b/examplenumbers_test.go
@@ -28,7 +28,7 @@ import (
 // not in possibleExpectedTypes.
 func checkNumbersValidAndCorrectType(exampleNumberRequestedType PhoneNumberType, possibleExpectedTypes map[PhoneNumberType]bool) (invalidCases, wrongTypeCases []*PhoneNumber) {
 	for regionCode := range GetSupportedRegions() {
-		exampleNumber := GetExampleNumberForType(regionCode, exampleNumberRequestedType)
+		exampleNumber := GetExampleNumberForTypeInRegion(regionCode, exampleNumberRequestedType)
 		if exampleNumber == nil {
 			continue
 		}
@@ -108,7 +108,7 @@ func TestCanBeInternationallyDialledExampleNumbers(t *testing.T) {
 			t.Errorf("error parsing no-international-dialling example for %s: %s", regionCode, err)
 			continue
 		}
-		if canBeInternationallyDialled(exampleNumber) {
+		if CanBeInternationallyDialled(exampleNumber) {
 			wrongTypeCases = append(wrongTypeCases, exampleNumber)
 		}
 	}
@@ -156,7 +156,7 @@ func TestEveryTypeHasAnExampleNumber(t *testing.T) {
 // one, falling back to non-geographical entities.
 func getExampleNumberForTypeAnyRegion(t *testing.T, typ PhoneNumberType) *PhoneNumber {
 	for regionCode := range GetSupportedRegions() {
-		if exampleNumber := GetExampleNumberForType(regionCode, typ); exampleNumber != nil {
+		if exampleNumber := GetExampleNumberForTypeInRegion(regionCode, typ); exampleNumber != nil {
 			return exampleNumber
 		}
 	}

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -599,7 +599,7 @@ func normalizeDigits(number string, keepNonDigits bool) string {
 // Normalizes a string of characters representing a phone number. This
 // strips all characters which are not diallable on a mobile phone
 // keypad (including all non-ASCII digits).
-func normalizeDiallableCharsOnly(number string) string {
+func NormalizeDiallableCharsOnly(number string) string {
 	return normalizeHelper(
 		number, DIALLABLE_CHAR_MAPPINGS, true /* remove non matches */)
 }
@@ -667,7 +667,7 @@ func GetLengthOfGeographicalAreaCode(number *PhoneNumber) int {
 		return 0
 	}
 
-	if !isNumberGeographical(number) {
+	if !IsNumberGeographical(number) {
 		return 0
 	}
 
@@ -865,11 +865,17 @@ func formattingRuleHasFirstGroupOnly(nationalPrefixFormattingRule string) bool {
 // overlap for geocodable and non-geocodable numbers. Also, if new phone
 // number types were added, we should check if this other method should be
 // updated too.
-func isNumberGeographical(phoneNumber *PhoneNumber) bool {
-	numberType := GetNumberType(phoneNumber)
-	return numberType == FIXED_LINE ||
-		numberType == FIXED_LINE_OR_MOBILE ||
-		(GEO_MOBILE_COUNTRIES[phoneNumber.GetCountryCode()] && numberType == MOBILE)
+func IsNumberGeographical(phoneNumber *PhoneNumber) bool {
+	return IsNumberGeographicalForType(GetNumberType(phoneNumber), int(phoneNumber.GetCountryCode()))
+}
+
+// Overload of IsNumberGeographical(PhoneNumber), since calculating the phone
+// number type is expensive; if we have already done this, we don't want to do
+// it again.
+func IsNumberGeographicalForType(phoneNumberType PhoneNumberType, countryCallingCode int) bool {
+	return phoneNumberType == FIXED_LINE ||
+		phoneNumberType == FIXED_LINE_OR_MOBILE ||
+		(GEO_MOBILE_COUNTRIES[int32(countryCallingCode)] && phoneNumberType == MOBILE)
 }
 
 // Helper function to check region code is not unknown or null.
@@ -1133,7 +1139,7 @@ func FormatNumberForMobileDialing(
 			// always works, except for numbers which might potentially be
 			// short numbers, which are always dialled in national format.
 			regionMetadata := getMetadataForRegion(regionCallingFrom)
-			if canBeInternationallyDialled(numberNoExt) && testNumberLength(GetNationalSignificantNumber(numberNoExt), regionMetadata, UNKNOWN) != TOO_SHORT {
+			if CanBeInternationallyDialled(numberNoExt) && testNumberLength(GetNationalSignificantNumber(numberNoExt), regionMetadata, UNKNOWN) != TOO_SHORT {
 				formattedNumber = Format(numberNoExt, INTERNATIONAL)
 			} else {
 				formattedNumber = Format(numberNoExt, NATIONAL)
@@ -1158,13 +1164,13 @@ func FormatNumberForMobileDialing(
 			if (regionCode == REGION_CODE_FOR_NON_GEO_ENTITY ||
 				((regionCode == "MX" || regionCode == "CL" || regionCode == "UZ") &&
 					isFixedLineOrMobile)) &&
-				canBeInternationallyDialled(numberNoExt) {
+				CanBeInternationallyDialled(numberNoExt) {
 				formattedNumber = Format(numberNoExt, INTERNATIONAL)
 			} else {
 				formattedNumber = Format(numberNoExt, NATIONAL)
 			}
 		}
-	} else if isValidNumber && canBeInternationallyDialled(numberNoExt) {
+	} else if isValidNumber && CanBeInternationallyDialled(numberNoExt) {
 		// We assume that short numbers are not diallable from outside
 		// their region, so if a number is not a valid regular length
 		// phone number, we treat it as if it cannot be internationally
@@ -1177,7 +1183,7 @@ func FormatNumberForMobileDialing(
 	if withFormatting {
 		return formattedNumber
 	}
-	return normalizeDiallableCharsOnly(formattedNumber)
+	return NormalizeDiallableCharsOnly(formattedNumber)
 }
 
 // Formats a phone number for out-of-country dialing purposes. If no
@@ -1359,8 +1365,8 @@ func FormatInOriginalFormat(number *PhoneNumber, regionCallingFrom string) strin
 	// formatting, we return the formatted phone number; otherwise we
 	// return the raw input the user entered.
 	if len(formattedNumber) != 0 && len(rawInput) > 0 {
-		normalizedFormattedNumber := normalizeDiallableCharsOnly(formattedNumber)
-		normalizedRawInput := normalizeDiallableCharsOnly(rawInput)
+		normalizedFormattedNumber := NormalizeDiallableCharsOnly(formattedNumber)
+		normalizedRawInput := NormalizeDiallableCharsOnly(rawInput)
 		if normalizedFormattedNumber != normalizedRawInput {
 			formattedNumber = rawInput
 		}
@@ -1726,7 +1732,7 @@ func formatNsnUsingPatternWithCarrier(
 
 // Gets a valid number for the specified region.
 func GetExampleNumber(regionCode string) *PhoneNumber {
-	return GetExampleNumberForType(regionCode, FIXED_LINE)
+	return GetExampleNumberForTypeInRegion(regionCode, FIXED_LINE)
 }
 
 // GetInvalidExampleNumber returns an invalid number for the specified region.
@@ -1758,7 +1764,10 @@ func GetInvalidExampleNumber(regionCode string) *PhoneNumber {
 }
 
 // Gets a valid number for the specified region and number type.
-func GetExampleNumberForType(regionCode string, typ PhoneNumberType) *PhoneNumber {
+//
+// This is the upstream getExampleNumberForType(String, PhoneNumberType)
+// overload; GetExampleNumberForType is the region-less variant.
+func GetExampleNumberForTypeInRegion(regionCode string, typ PhoneNumberType) *PhoneNumber {
 	// Check the region code is valid.
 	if !isValidRegionCode(regionCode) {
 		return nil
@@ -1773,6 +1782,29 @@ func GetExampleNumberForType(regionCode string, typ PhoneNumberType) *PhoneNumbe
 		}
 		return num
 	}
+	return nil
+}
+
+// Gets a valid number for the specified number type (it may belong to any
+// country).
+func GetExampleNumberForType(typ PhoneNumberType) *PhoneNumber {
+	for regionCode := range GetSupportedRegions() {
+		exampleNumber := GetExampleNumberForTypeInRegion(regionCode, typ)
+		if exampleNumber != nil {
+			return exampleNumber
+		}
+	}
+	// If there wasn't an example number for a region, try the non-geographical entities.
+	for countryCallingCode := range GetSupportedGlobalNetworkCallingCodes() {
+		desc := getNumberDescByType(getMetadataForNonGeographicalRegion(countryCallingCode), typ)
+		if exNum := desc.GetExampleNumber(); len(exNum) > 0 {
+			num, err := Parse("+"+strconv.Itoa(countryCallingCode)+exNum, UNKNOWN_REGION)
+			if err == nil {
+				return num
+			}
+		}
+	}
+	// There are no example numbers of this type for any country in the library.
 	return nil
 }
 
@@ -2135,6 +2167,27 @@ func IsAlphaNumber(number string) bool {
 func IsPossibleNumber(number *PhoneNumber) bool {
 	possible := IsPossibleNumberWithReason(number)
 	return possible == IS_POSSIBLE || possible == IS_POSSIBLE_LOCAL_ONLY
+}
+
+// IsPossibleNumberFromRegion checks whether a phone number is a possible number
+// given a number in the form of a string, and the region where the number could
+// be dialled from. It provides a more lenient check than IsValidNumber. See
+// IsPossibleNumber for details.
+//
+// This method first parses the number, then invokes IsPossibleNumber with the
+// resultant PhoneNumber object.
+//
+// regionDialingFrom is the region we expect the number to be dialled from. Note
+// this is different from the region where the number belongs. For example, the
+// number +1 650 253 0000 belongs to the US. When written in this form, it can
+// be dialled from any region. When written as 650 253 0000, it can only be
+// dialled from within the US.
+func IsPossibleNumberFromRegion(number string, regionDialingFrom string) bool {
+	num, err := Parse(number, regionDialingFrom)
+	if err != nil {
+		return false
+	}
+	return IsPossibleNumber(num)
 }
 
 // descHasPossibleNumberData returns true if there is any possible-length data
@@ -3122,9 +3175,9 @@ func IsNumberMatchWithOneNumber(
 // Returns true if the number can be dialled from outside the region, or
 // unknown. If the number can only be dialled from within the region,
 // returns false. Does not check the number is a valid number. Note that,
-// at the moment, this method does not handle short numbers.
-// TODO: Make this method public when we have enough metadata to make it worthwhile.
-func canBeInternationallyDialled(number *PhoneNumber) bool {
+// at the moment, this method does not handle short numbers (which are
+// currently all presumed to not be diallable from outside their country).
+func CanBeInternationallyDialled(number *PhoneNumber) bool {
 	metadata := getMetadataForRegion(GetRegionCodeForNumber(number))
 	if metadata == nil {
 		// Note numbers belonging to non-geographical entities

--- a/phonenumberutil_normalize_test.go
+++ b/phonenumberutil_normalize_test.go
@@ -43,7 +43,7 @@ func TestNormaliseStripAlphaCharacters(t *testing.T) {
 
 // testNormaliseStripNonDiallableCharacters (PhoneNumberUtilTest.java:487-493)
 func TestNormaliseStripNonDiallableCharacters(t *testing.T) {
-	assert.Equal(t, "03*456+1#234", normalizeDiallableCharsOnly("03*4-56&+1a#234"), "Conversion did not correctly remove non-diallable characters")
+	assert.Equal(t, "03*456+1#234", NormalizeDiallableCharsOnly("03*4-56&+1a#234"), "Conversion did not correctly remove non-diallable characters")
 }
 
 // testIsViablePhoneNumber (PhoneNumberUtilTest.java:1798-1813)

--- a/phonenumberutil_possibility_test.go
+++ b/phonenumberutil_possibility_test.go
@@ -11,19 +11,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// possibleWithRegion is the test-local stand-in for upstream's
-// isPossibleNumber(CharSequence, regionDialingFrom) overload, which the Go API
-// does not expose (only the *PhoneNumber form). It parses then checks
-// possibility, returning false if parsing fails — mirroring upstream's catch of
-// NumberParseException.
-func possibleWithRegion(number, regionDialingFrom string) bool {
-	num, err := Parse(number, regionDialingFrom)
-	if err != nil {
-		return false
-	}
-	return IsPossibleNumber(num)
-}
-
 // testIsPossibleNumber (PhoneNumberUtilTest.java:1375-1391)
 func TestIsPossibleNumber(t *testing.T) {
 	useTestMetadata(t)
@@ -32,16 +19,16 @@ func TestIsPossibleNumber(t *testing.T) {
 	assert.True(t, IsPossibleNumber(gbNumber()))
 	assert.True(t, IsPossibleNumber(internationalTollFree()))
 
-	assert.True(t, possibleWithRegion("+1 650 253 0000", regionCode.US))
-	assert.True(t, possibleWithRegion("+1 650 GOO OGLE", regionCode.US))
-	assert.True(t, possibleWithRegion("(650) 253-0000", regionCode.US))
-	assert.True(t, possibleWithRegion("253-0000", regionCode.US))
-	assert.True(t, possibleWithRegion("+1 650 253 0000", regionCode.GB))
-	assert.True(t, possibleWithRegion("+44 20 7031 3000", regionCode.GB))
-	assert.True(t, possibleWithRegion("(020) 7031 300", regionCode.GB))
-	assert.True(t, possibleWithRegion("7031 3000", regionCode.GB))
-	assert.True(t, possibleWithRegion("3331 6005", regionCode.NZ))
-	assert.True(t, possibleWithRegion("+800 1234 5678", regionCode.UN001))
+	assert.True(t, IsPossibleNumberFromRegion("+1 650 253 0000", regionCode.US))
+	assert.True(t, IsPossibleNumberFromRegion("+1 650 GOO OGLE", regionCode.US))
+	assert.True(t, IsPossibleNumberFromRegion("(650) 253-0000", regionCode.US))
+	assert.True(t, IsPossibleNumberFromRegion("253-0000", regionCode.US))
+	assert.True(t, IsPossibleNumberFromRegion("+1 650 253 0000", regionCode.GB))
+	assert.True(t, IsPossibleNumberFromRegion("+44 20 7031 3000", regionCode.GB))
+	assert.True(t, IsPossibleNumberFromRegion("(020) 7031 300", regionCode.GB))
+	assert.True(t, IsPossibleNumberFromRegion("7031 3000", regionCode.GB))
+	assert.True(t, IsPossibleNumberFromRegion("3331 6005", regionCode.NZ))
+	assert.True(t, IsPossibleNumberFromRegion("+800 1234 5678", regionCode.UN001))
 }
 
 // testIsPossibleNumberWithReason (PhoneNumberUtilTest.java:1475-1500)
@@ -77,13 +64,13 @@ func TestIsNotPossibleNumber(t *testing.T) {
 
 	number = &PhoneNumber{CountryCode: proto.Int32(44), NationalNumber: proto.Uint64(300)}
 	assert.False(t, IsPossibleNumber(number))
-	assert.False(t, possibleWithRegion("+1 650 253 00000", regionCode.US))
-	assert.False(t, possibleWithRegion("(650) 253-00000", regionCode.US))
-	assert.False(t, possibleWithRegion("I want a Pizza", regionCode.US))
-	assert.False(t, possibleWithRegion("253-000", regionCode.US))
-	assert.False(t, possibleWithRegion("1 3000", regionCode.GB))
-	assert.False(t, possibleWithRegion("+44 300", regionCode.GB))
-	assert.False(t, possibleWithRegion("+800 1234 5678 9", regionCode.UN001))
+	assert.False(t, IsPossibleNumberFromRegion("+1 650 253 00000", regionCode.US))
+	assert.False(t, IsPossibleNumberFromRegion("(650) 253-00000", regionCode.US))
+	assert.False(t, IsPossibleNumberFromRegion("I want a Pizza", regionCode.US))
+	assert.False(t, IsPossibleNumberFromRegion("253-000", regionCode.US))
+	assert.False(t, IsPossibleNumberFromRegion("1 3000", regionCode.GB))
+	assert.False(t, IsPossibleNumberFromRegion("+44 300", regionCode.GB))
+	assert.False(t, IsPossibleNumberFromRegion("+800 1234 5678 9", regionCode.UN001))
 }
 
 // testTruncateTooLongNumber (PhoneNumberUtilTest.java:1747-1796)

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -193,13 +193,13 @@ func TestGetInstanceLoadInternationalTollFreeMetadata(t *testing.T) {
 
 func TestIsNumberGeographical(t *testing.T) {
 	useTestMetadata(t)
-	assert.False(t, isNumberGeographical(bsMobile()))              // Bahamas, mobile phone number.
-	assert.True(t, isNumberGeographical(auNumber()))               // Australian fixed line number.
-	assert.False(t, isNumberGeographical(internationalTollFree())) // International toll free number.
+	assert.False(t, IsNumberGeographical(bsMobile()))              // Bahamas, mobile phone number.
+	assert.True(t, IsNumberGeographical(auNumber()))               // Australian fixed line number.
+	assert.False(t, IsNumberGeographical(internationalTollFree())) // International toll free number.
 	// We test that mobile phone numbers in relevant regions are indeed considered geographical.
-	assert.True(t, isNumberGeographical(arMobile()))  // Argentina, mobile phone number.
-	assert.True(t, isNumberGeographical(mxMobile1())) // Mexico, mobile phone number.
-	assert.True(t, isNumberGeographical(mxMobile2())) // Mexico, another mobile phone number.
+	assert.True(t, IsNumberGeographical(arMobile()))  // Argentina, mobile phone number.
+	assert.True(t, IsNumberGeographical(mxMobile1())) // Mexico, mobile phone number.
+	assert.True(t, IsNumberGeographical(mxMobile2())) // Mexico, another mobile phone number.
 }
 
 func TestGetLengthOfGeographicalAreaCode(t *testing.T) {
@@ -328,16 +328,16 @@ func TestGetExampleNumber(t *testing.T) {
 	useTestMetadata(t)
 	assert.True(t, proto.Equal(deNumber(), GetExampleNumber(regionCode.DE)))
 
-	assert.True(t, proto.Equal(deNumber(), GetExampleNumberForType(regionCode.DE, FIXED_LINE)))
+	assert.True(t, proto.Equal(deNumber(), GetExampleNumberForTypeInRegion(regionCode.DE, FIXED_LINE)))
 	// Should return the same response if asked for FIXED_LINE_OR_MOBILE too.
-	assert.True(t, proto.Equal(deNumber(), GetExampleNumberForType(regionCode.DE, FIXED_LINE_OR_MOBILE)))
-	assert.NotNil(t, GetExampleNumberForType(regionCode.US, FIXED_LINE))
-	assert.NotNil(t, GetExampleNumberForType(regionCode.US, MOBILE))
+	assert.True(t, proto.Equal(deNumber(), GetExampleNumberForTypeInRegion(regionCode.DE, FIXED_LINE_OR_MOBILE)))
+	assert.NotNil(t, GetExampleNumberForTypeInRegion(regionCode.US, FIXED_LINE))
+	assert.NotNil(t, GetExampleNumberForTypeInRegion(regionCode.US, MOBILE))
 
 	// We have data for the US, but no data for VOICEMAIL, so return null.
-	assert.Nil(t, GetExampleNumberForType(regionCode.US, VOICEMAIL))
+	assert.Nil(t, GetExampleNumberForTypeInRegion(regionCode.US, VOICEMAIL))
 	// CS is an invalid region, so we have no data for it.
-	assert.Nil(t, GetExampleNumberForType("CS", MOBILE))
+	assert.Nil(t, GetExampleNumberForTypeInRegion("CS", MOBILE))
 	// RegionCode 001 is reserved for supporting non-geographical country calling code. We don't
 	// support getting an example number for it with this method.
 	assert.Nil(t, GetExampleNumber(regionCode.UN001))
@@ -352,24 +352,9 @@ func TestGetExampleNumberForNonGeoEntity(t *testing.T) {
 func TestGetExampleNumberWithoutRegion(t *testing.T) {
 	useTestMetadata(t)
 	// In our test metadata we don't cover all types: in our real metadata, we do.
-	// NOTE: the Go API has no region-less GetExampleNumberForType overload (an
-	// upstream API gap, tracked separately), so this mirrors the Java intent by
-	// iterating the supported regions and returning the first example for the type.
-	assert.NotNil(t, exampleNumberForTypeAnyRegion(FIXED_LINE))
-	assert.NotNil(t, exampleNumberForTypeAnyRegion(MOBILE))
-	assert.NotNil(t, exampleNumberForTypeAnyRegion(PREMIUM_RATE))
-}
-
-// exampleNumberForTypeAnyRegion is the test-local stand-in for upstream's
-// getExampleNumberForType(PhoneNumberType) no-region overload: it iterates every
-// supported region and returns the first example number found for the given type.
-func exampleNumberForTypeAnyRegion(typ PhoneNumberType) *PhoneNumber {
-	for regionCode := range GetSupportedRegions() {
-		if example := GetExampleNumberForType(regionCode, typ); example != nil {
-			return example
-		}
-	}
-	return nil
+	assert.NotNil(t, GetExampleNumberForType(FIXED_LINE))
+	assert.NotNil(t, GetExampleNumberForType(MOBILE))
+	assert.NotNil(t, GetExampleNumberForType(PREMIUM_RATE))
 }
 
 func TestIsPremiumRate(t *testing.T) {
@@ -628,17 +613,17 @@ func TestCanBeInternationallyDialled(t *testing.T) {
 	useTestMetadata(t)
 	// We have no-international-dialling rules for the US in our test metadata that
 	// say that toll-free numbers cannot be dialled internationally.
-	assert.False(t, canBeInternationallyDialled(usTollFree()))
+	assert.False(t, CanBeInternationallyDialled(usTollFree()))
 
 	// Normal US numbers can be internationally dialled.
-	assert.True(t, canBeInternationallyDialled(usNumber()))
+	assert.True(t, CanBeInternationallyDialled(usNumber()))
 
 	// Invalid number.
-	assert.True(t, canBeInternationallyDialled(usLocalNumber()))
+	assert.True(t, CanBeInternationallyDialled(usLocalNumber()))
 
 	// We have no data for NZ - should return true.
-	assert.True(t, canBeInternationallyDialled(nzNumber()))
-	assert.True(t, canBeInternationallyDialled(internationalTollFree()))
+	assert.True(t, CanBeInternationallyDialled(nzNumber()))
+	assert.True(t, CanBeInternationallyDialled(internationalTollFree()))
 }
 
 func TestIsAlphaNumber(t *testing.T) {


### PR DESCRIPTION
Closes naming/surface gaps found while comparing the exported Go API against the upstream Java `PhoneNumberUtil` reference (baseline v9.0.31).

## Export methods that are `public` in Java but were unexported here
| Now exported | Java |
|---|---|
| `NormalizeDiallableCharsOnly` | `normalizeDiallableCharsOnly` — parity with the already-exported `NormalizeDigitsOnly` |
| `IsNumberGeographical` | `isNumberGeographical` |
| `CanBeInternationallyDialled` | `canBeInternationallyDialled` |

`CanBeInternationallyDialled` also drops a stale `TODO: make this method public` comment and aligns its doc text with current upstream (which made it public long ago). British `Dialled`/`Diallable` spelling kept, matching Java.

## Port three Java overloads that had no Go equivalent
Go has no overloading, so each gets a distinct name:

| New Go function | Java overload |
|---|---|
| `IsPossibleNumberFromRegion(number, regionDialingFrom string) bool` | `isPossibleNumber(CharSequence, String)` — parses then checks possibility |
| `GetExampleNumberForType(typ PhoneNumberType) *PhoneNumber` | `getExampleNumberForType(PhoneNumberType)` — region-less; scans all regions then non-geo entities |
| `IsNumberGeographicalForType(type PhoneNumberType, countryCallingCode int) bool` | `isNumberGeographical(PhoneNumberType, int)` — the cheap overload when type is known |

`IsNumberGeographical(*PhoneNumber)` now delegates to `IsNumberGeographicalForType`, exactly as Java's single-arg form delegates to the two-arg one.

## ⚠️ Breaking change
The previous two-arg `GetExampleNumberForType(regionCode, typ)` is **renamed to `GetExampleNumberForTypeInRegion`**, freeing the bare name for the region-less overload so it matches Java's `getExampleNumberForType(type)` exactly. Callers of the two-arg form must update the name (signature unchanged).

## Tests
Three test files carried local stand-ins written *because* these overloads were missing — `possibleWithRegion` and `exampleNumberForTypeAnyRegion`. Both are removed in favor of the real functions, restoring faithful ports of the corresponding upstream test cases (`testIsPossibleNumber`, `testGetExampleNumberWithoutRegion`). `IsNumberGeographicalForType` has no dedicated upstream test (Java only tests the single-arg form) and is covered via delegation.

## Skill
Adds a bullet to the `sync-upstream` skill on mapping Java overloads to distinct Go names, so future syncs fill such gaps consistently rather than skipping them (and clarifies that porting an existing upstream overload is faithful porting, not the "don't add API" case).

Verified: `gofmt` clean, `go build ./...`, `go vet`, and full `go test ./...` all pass.