### PR TITLE
Align carrier/geocoding/timezone subpackages with upstream Java

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -27,3 +27,9 @@ Places where this port intentionally differs from upstream:
   `testGetMetadataForRegionForMissingMetadata` and its non-geographical variant (both rely on
   Mockito-style metadata-source injection), and `testRemovalNotSupported` (Go's range-over-func
   iterator has no `remove()`).
+- **Lookup-subpackage naming** — `carrier`, `geocoding`, and `timezone` keep the upstream
+  method *behaviour* but drop the Java `get` prefix (`getNameForNumber` → `carrier.NameForNumber`,
+  `getDescriptionForNumber` → `geocoding.DescriptionForNumber`, `getTimeZonesForNumber` →
+  `timezone.TimeZonesForNumber`), and `getUnknownTimeZone()` is the `timezone.Unknown` const.
+  `geocoding` renders the country name via `golang.org/x/text` rather than `java.util.Locale`.
+  Don't "restore" the `Get` prefix on a sync.

--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -13,37 +13,40 @@ var carrierData embed.FS
 
 var mapper = prefixmapper.New(carrierData, "data")
 
-// ForNumber returns the carrier we believe the number belongs to. Note due
-// to number porting this is only a guess, there is no guarantee to its accuracy.
-func ForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
-	carrier, _, err := WithPrefixForNumber(number, lang)
-	return carrier, err
+// NameForValidNumber returns the carrier we believe the number belongs to. Note
+// due to number porting this is only a guess; there is no guarantee of its
+// accuracy. The number is assumed to be valid.
+func NameForValidNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+	e164 := phonenumbers.Format(number, phonenumbers.E164)
+	name, _, err := mapper.ValueForNumber(lang, 10, e164)
+	return name, err
 }
 
-// SafeDisplayName gets the name of the carrier for the given phone number
-// only when it is 'safe' to display to users.
-// A carrier name is considered safe if the number is valid and
-// for a region that doesn't support mobile number portability .
+// NameForNumber returns the carrier we believe the number belongs to. Note due
+// to number porting this is only a guess; there is no guarantee of its accuracy.
+// A carrier name is only returned for numbers of a mobile type.
+func NameForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+	if isMobile(phonenumbers.GetNumberType(number)) {
+		return NameForValidNumber(number, lang)
+	}
+	return "", nil
+}
+
+// SafeDisplayName gets the name of the carrier for the given phone number only
+// when it is 'safe' to display to users. A carrier name is considered safe if
+// the number is valid and for a region that doesn't support mobile number
+// portability.
 func SafeDisplayName(number *phonenumbers.PhoneNumber, lang string) (string, error) {
 	if phonenumbers.IsMobileNumberPortableRegion(phonenumbers.GetRegionCodeForNumber(number)) {
 		return "", nil
 	}
-	return ForNumber(number, lang)
+	return NameForNumber(number, lang)
 }
 
-// WithPrefixForNumber returns the carrier we believe the number belongs to, as well as
-// its prefix. Note due to number porting this is only a guess, there is no guarantee to its accuracy.
-func WithPrefixForNumber(number *phonenumbers.PhoneNumber, lang string) (string, int, error) {
-	e164 := phonenumbers.Format(number, phonenumbers.E164)
-
-	carrier, prefix, err := mapper.ValueForNumber(lang, 10, e164)
-	if err != nil {
-		return "", 0, err
-	}
-	if carrier != "" {
-		return carrier, prefix, nil
-	}
-
-	// fallback to english
-	return mapper.ValueForNumber("en", 10, e164)
+// isMobile reports whether numberType is a mobile type that a carrier can be
+// looked up for.
+func isMobile(numberType phonenumbers.PhoneNumberType) bool {
+	return numberType == phonenumbers.MOBILE ||
+		numberType == phonenumbers.FIXED_LINE_OR_MOBILE ||
+		numberType == phonenumbers.PAGER
 }

--- a/carrier/carrier_test.go
+++ b/carrier/carrier_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nyaruka/phonenumbers/v2"
 )
 
-func TestForNumber(t *testing.T) {
+func TestNameForNumber(t *testing.T) {
 	tests := []struct {
 		num      string
 		lang     string
@@ -20,15 +20,19 @@ func TestForNumber(t *testing.T) {
 		{num: "+61491570156", lang: "en", expected: "Telstra"},
 		{num: "+917999999543", lang: "en", expected: "Reliance Jio"},
 		{num: "+593992218722", lang: "en", expected: "Claro"},
+		// no carrier data for the number
+		{num: "+201987654321", lang: "en", expected: ""},
+		// no data for the requested language (and no English fallback)
+		{num: "+201987654321", lang: "notFound", expected: ""},
 	}
 	for _, test := range tests {
 		number, err := phonenumbers.Parse(test.num, "ZZ")
 		if err != nil {
 			t.Errorf("Failed to parse number %s: %s", test.num, err)
 		}
-		carrier, err := ForNumber(number, test.lang)
+		carrier, err := NameForNumber(number, test.lang)
 		if err != nil {
-			t.Errorf("Failed to getCarrier for the number %s: %s", test.num, err)
+			t.Errorf("Failed to get carrier for the number %s: %s", test.num, err)
 		}
 		if test.expected != carrier {
 			t.Errorf("Expected '%s', got '%s' for '%s'", test.expected, carrier, test.num)
@@ -36,42 +40,7 @@ func TestForNumber(t *testing.T) {
 	}
 }
 
-func TestWithPrefixForNumber(t *testing.T) {
-	tests := []struct {
-		num             string
-		lang            string
-		expectedCarrier string
-		expectedPrefix  int
-	}{
-		{num: "+8613702032331", lang: "en", expectedCarrier: "China Mobile", expectedPrefix: 86137},
-		{num: "+8613702032331", lang: "zh", expectedCarrier: "中国移动", expectedPrefix: 86137},
-		{num: "+6281377468527", lang: "en", expectedCarrier: "Telkomsel", expectedPrefix: 62813},
-		{num: "+8613323241342", lang: "en", expectedCarrier: "China Telecom", expectedPrefix: 86133},
-		{num: "+61491570156", lang: "en", expectedCarrier: "Telstra", expectedPrefix: 6149},
-		{num: "+917999999543", lang: "en", expectedCarrier: "Reliance Jio", expectedPrefix: 917999},
-		{num: "+593992218722", lang: "en", expectedCarrier: "Claro", expectedPrefix: 5939922},
-		{num: "+201987654321", lang: "en", expectedCarrier: "", expectedPrefix: 0},
-		{num: "+201987654321", lang: "notFound", expectedCarrier: "", expectedPrefix: 0},
-	}
-	for _, test := range tests {
-		number, err := phonenumbers.Parse(test.num, "ZZ")
-		if err != nil {
-			t.Errorf("Failed to parse number %s: %s", test.num, err)
-		}
-		carrier, prefix, err := WithPrefixForNumber(number, test.lang)
-		if err != nil {
-			t.Errorf("Failed to getCarrierWithPrefix for the number %s: %s", test.num, err)
-		}
-		if test.expectedCarrier != carrier {
-			t.Errorf("Expected '%s', got '%s' for '%s'", test.expectedCarrier, carrier, test.num)
-		}
-		if test.expectedPrefix != prefix {
-			t.Errorf("Expected '%d', got '%d' for '%s'", test.expectedPrefix, prefix, test.num)
-		}
-	}
-}
-
-func TestWithPrefixForNumberConcurrency(t *testing.T) {
+func TestNameForNumberConcurrency(t *testing.T) {
 	number, _ := phonenumbers.Parse("+8613702032331", "ZZ")
 
 	wg := sync.WaitGroup{}
@@ -80,9 +49,9 @@ func TestWithPrefixForNumberConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _, err := WithPrefixForNumber(number, "en")
+			_, err := NameForNumber(number, "en")
 			if err != nil {
-				t.Errorf("Failed to getCarrierWithPrefix for the number %s: %s", "+8613702032331", err)
+				t.Errorf("Failed to get carrier for the number %s: %s", "+8613702032331", err)
 			}
 		}()
 	}
@@ -114,13 +83,13 @@ func TestSafeDisplayName(t *testing.T) {
 	}
 }
 
-func BenchmarkWithPrefixForNumber(b *testing.B) {
+func BenchmarkNameForNumber(b *testing.B) {
 	number, _ := phonenumbers.Parse("+8613702032331", "ZZ")
 
 	for n := 0; n < b.N; n++ {
-		_, _, err := WithPrefixForNumber(number, "en")
+		_, err := NameForNumber(number, "en")
 		if err != nil {
-			b.Errorf("Failed to getCarrierWithPrefix for the number %s: %s", "+8613702032331", err)
+			b.Errorf("Failed to get carrier for the number %s: %s", "+8613702032331", err)
 		}
 	}
 }

--- a/geocoding/geocoding.go
+++ b/geocoding/geocoding.go
@@ -3,6 +3,7 @@ package geocoding
 
 import (
 	"embed"
+	"strings"
 
 	"github.com/nyaruka/phonenumbers/v2"
 	"github.com/nyaruka/phonenumbers/v2/internal/prefixmapper"
@@ -15,31 +16,83 @@ var geocodingData embed.FS
 
 var mapper = prefixmapper.New(geocodingData, "data")
 
-// ForNumber returns the location we think the number was first acquired in. This is
-// just our best guess, there is no guarantee to its accuracy.
-func ForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
-	e164 := phonenumbers.Format(number, phonenumbers.E164)
+// DescriptionForValidNumber returns a text description in the given language for
+// the geographical area the number is from, falling back to the country name.
+// The number is assumed to be valid.
+func DescriptionForValidNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+	mobileToken := phonenumbers.GetCountryMobileToken(int(number.GetCountryCode()))
+	nationalNumber := phonenumbers.GetNationalSignificantNumber(number)
 
-	geocoding, _, err := mapper.ValueForNumber(lang, 10, e164)
-	if err != nil || geocoding != "" {
-		return geocoding, err
+	lookupNumber := number
+	if mobileToken != "" && strings.HasPrefix(nationalNumber, mobileToken) {
+		// In some countries, e.g. Argentina, mobile numbers have a mobile token before the
+		// national destination code; this should be removed before geocoding.
+		region := phonenumbers.GetRegionCodeForCountryCode(int(number.GetCountryCode()))
+		if copied, err := phonenumbers.Parse(nationalNumber[len(mobileToken):], region); err == nil {
+			lookupNumber = copied
+		}
 	}
 
-	// fallback to english
-	geocoding, _, err = mapper.ValueForNumber("en", 10, e164)
-	if err != nil || geocoding != "" {
-		return geocoding, err
-	}
-
-	// fallback to locale
-	var reg language.Region
-	if reg, err = language.ParseRegion(phonenumbers.GetRegionCodeForNumber(number)); err != nil {
+	e164 := phonenumbers.Format(lookupNumber, phonenumbers.E164)
+	areaDescription, _, err := mapper.ValueForNumber(lang, 10, e164)
+	if err != nil {
 		return "", err
 	}
-
-	var langT language.Tag
-	if langT, err = language.Parse(lang); err != nil {
-		langT = language.English // fallback to english
+	if areaDescription != "" {
+		return areaDescription, nil
 	}
-	return display.Regions(langT).Name(reg), nil
+	return countryNameForNumber(number, lang)
+}
+
+// DescriptionForNumber returns a text description in the given language for the
+// given phone number: the name of the geographical area it is from for
+// geographical numbers, otherwise the name of the country, and the empty string
+// for numbers of an unknown type.
+func DescriptionForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+	numberType := phonenumbers.GetNumberType(number)
+	if numberType == phonenumbers.UNKNOWN {
+		return "", nil
+	} else if !phonenumbers.IsNumberGeographicalForType(numberType, int(number.GetCountryCode())) {
+		return countryNameForNumber(number, lang)
+	}
+	return DescriptionForValidNumber(number, lang)
+}
+
+// countryNameForNumber returns the name of the country, in the given language,
+// for the region the number is from, returning the empty string when the number
+// is valid for more than one region and a single one cannot be determined.
+func countryNameForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+	regionCodes := phonenumbers.GetRegionCodesForCountryCode(int(number.GetCountryCode()))
+	if len(regionCodes) == 1 {
+		return regionDisplayName(regionCodes[0], lang), nil
+	}
+	regionWhereValid := "ZZ"
+	for _, regionCode := range regionCodes {
+		if phonenumbers.IsValidNumberForRegion(number, regionCode) {
+			// If the number has already been found valid for one region, then we don't know
+			// which region it belongs to so we return nothing.
+			if regionWhereValid != "ZZ" {
+				return "", nil
+			}
+			regionWhereValid = regionCode
+		}
+	}
+	return regionDisplayName(regionWhereValid, lang), nil
+}
+
+// regionDisplayName returns the localized country name for a region code, or the
+// empty string for unknown or non-geographical regions.
+func regionDisplayName(regionCode, lang string) string {
+	if regionCode == "" || regionCode == "ZZ" || regionCode == phonenumbers.REGION_CODE_FOR_NON_GEO_ENTITY {
+		return ""
+	}
+	reg, err := language.ParseRegion(regionCode)
+	if err != nil {
+		return ""
+	}
+	langT, err := language.Parse(lang)
+	if err != nil {
+		langT = language.English // fall back to english only for rendering the country name
+	}
+	return display.Regions(langT).Name(reg)
 }

--- a/geocoding/geocoding_test.go
+++ b/geocoding/geocoding_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nyaruka/phonenumbers/v2"
 )
 
-func TestForNumber(t *testing.T) {
+func TestDescriptionForNumber(t *testing.T) {
 	tests := []struct {
 		num      string
 		lang     string
@@ -28,9 +28,9 @@ func TestForNumber(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to parse number %s: %s", test.num, err)
 		}
-		geocoding, err := ForNumber(number, test.lang)
+		geocoding, err := DescriptionForNumber(number, test.lang)
 		if err != nil {
-			t.Errorf("Failed to getGeocoding for the number %s: %s", test.num, err)
+			t.Errorf("Failed to get description for the number %s: %s", test.num, err)
 		}
 		if test.expected != geocoding {
 			t.Errorf("Expected '%s', got '%s' for '%s'", test.expected, geocoding, test.num)

--- a/timezone/timezone.go
+++ b/timezone/timezone.go
@@ -24,11 +24,38 @@ var (
 	timezoneMap  *serialize.IntStringArrayMap
 )
 
-// ForPrefix returns a slice of Timezones corresponding to the number passed
-// or error when it is impossible to convert the string to int
-// The algorithm tries to match the timezones starting from the maximum
-// number of phone number digits and decreasing until it finds one or reaches 0
-func ForPrefix(number string) ([]string, error) {
+// TimeZonesForNumber returns the names of the timezones to which the given
+// number maps. An unknown-type number maps to the unknown timezone; a
+// non-geographical number is resolved at the country-calling-code level; any
+// other number is resolved from its full digits.
+func TimeZonesForNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
+	numberType := phonenumbers.GetNumberType(number)
+	if numberType == phonenumbers.UNKNOWN {
+		return []string{Unknown}, nil
+	} else if !phonenumbers.IsNumberGeographicalForType(numberType, int(number.GetCountryCode())) {
+		return countryLevelTimeZonesForNumber(number)
+	}
+	return TimeZonesForGeographicalNumber(number)
+}
+
+// TimeZonesForGeographicalNumber returns the names of the timezones to which the
+// given geographical number maps, resolved from its full digits.
+func TimeZonesForGeographicalNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
+	e164 := phonenumbers.Format(number, phonenumbers.E164)
+	return lookupTimeZones(e164)
+}
+
+// countryLevelTimeZonesForNumber resolves the timezones for a number using only
+// its country calling code.
+func countryLevelTimeZonesForNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
+	return lookupTimeZones(strconv.Itoa(int(number.GetCountryCode())))
+}
+
+// lookupTimeZones returns the timezones for the longest matching prefix of the
+// given number string, or the unknown timezone when none matches. The algorithm
+// tries to match starting from the maximum number of digits and decreasing until
+// it finds one or reaches 0.
+func lookupTimeZones(number string) ([]string, error) {
 	var err error
 	timezoneOnce.Do(func() {
 		timezoneMap, err = serialize.LoadIntArrayMap(timezoneData)
@@ -54,11 +81,4 @@ func ForPrefix(number string) ([]string, error) {
 		}
 	}
 	return []string{Unknown}, nil
-}
-
-// ForNumber returns the names of timezones which we believe maps to the
-// passed in number.
-func ForNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
-	e164 := phonenumbers.Format(number, phonenumbers.E164)
-	return ForPrefix(e164)
 }

--- a/timezone/timezone_test.go
+++ b/timezone/timezone_test.go
@@ -12,130 +12,82 @@ type timeZonesTestCases struct {
 	expectedTimeZones []string
 }
 
-func TestForPrefix(t *testing.T) {
+func TestTimeZonesForNumber(t *testing.T) {
 	tests := []timeZonesTestCases{
-		{
-			num:               "+442073238299",
-			expectedTimeZones: []string{"Europe/London"},
-		},
-		{
-			num:               "+61491570156",
-			expectedTimeZones: []string{"Australia/Sydney"},
-		},
-		{
-			num:               "+61255501234",
-			expectedTimeZones: []string{"Australia/Sydney"},
-		},
-		{
-			num:               "+12067798181",
-			expectedTimeZones: []string{"America/Los_Angeles"},
-		},
-		{
-			num:               "+390399123456",
-			expectedTimeZones: []string{"Europe/Rome"},
-		},
-		{
-			num:               "+541151123456",
-			expectedTimeZones: []string{"America/Buenos_Aires"},
-		},
-		{
-			num:               "+15167706076",
-			expectedTimeZones: []string{"America/New_York"},
-		},
-		{
-			num:               "+917999999543",
-			expectedTimeZones: []string{"Asia/Calcutta"},
-		},
-		{
-			num:               "+540111561234567",
-			expectedTimeZones: []string{"America/Buenos_Aires"},
-		},
-		{
-			num:               "+18504320800",
-			expectedTimeZones: []string{"America/Chicago"},
-		},
-		{
-			num:               "+14079395277",
-			expectedTimeZones: []string{"America/New_York"},
-		},
-		{
-			num:               "+18508632167",
-			expectedTimeZones: []string{"America/Chicago"},
-		},
-		{
-			num:               "+40213158207",
-			expectedTimeZones: []string{"Europe/Bucharest"},
-		},
+		{num: "+442073238299", expectedTimeZones: []string{"Europe/London"}},
+		{num: "+61255501234", expectedTimeZones: []string{"Australia/Sydney"}},
+		{num: "+12067798181", expectedTimeZones: []string{"America/Los_Angeles"}},
+		{num: "+390399123456", expectedTimeZones: []string{"Europe/Rome"}},
+		{num: "+541151123456", expectedTimeZones: []string{"America/Buenos_Aires"}},
+		{num: "+15167706076", expectedTimeZones: []string{"America/New_York"}},
+		{num: "+917999999543", expectedTimeZones: []string{"Asia/Calcutta"}},
+		{num: "+540111561234567", expectedTimeZones: []string{"America/Buenos_Aires"}},
+		{num: "+18504320800", expectedTimeZones: []string{"America/Chicago"}},
+		{num: "+14079395277", expectedTimeZones: []string{"America/New_York"}},
+		{num: "+18508632167", expectedTimeZones: []string{"America/Chicago"}},
+		{num: "+40213158207", expectedTimeZones: []string{"Europe/Bucharest"}},
 		// UTC +5:45
-		{
-			num:               "+97714240520",
-			expectedTimeZones: []string{"Asia/Katmandu"},
-		},
+		{num: "+97714240520", expectedTimeZones: []string{"Asia/Katmandu"}},
 		// UTC -3:30
-		{
-			num:               "+17097264534",
-			expectedTimeZones: []string{"America/St_Johns"},
-		},
-		{
-			num:               "0000000000",
-			expectedTimeZones: []string{Unknown},
-		},
-		{
-			num:               "+31112",
-			expectedTimeZones: []string{"Europe/Amsterdam"},
-		},
-		{
-			num:               "+6837000",
-			expectedTimeZones: []string{"Pacific/Niue"},
-		},
-		{
-			num: "+1911",
-			expectedTimeZones: []string{
-				"America/Adak", "America/Anchorage", "America/Anguilla", "America/Antigua",
-				"America/Barbados", "America/Boise", "America/Cayman", "America/Chicago",
-				"America/Denver", "America/Dominica", "America/Edmonton", "America/Fort_Nelson",
-				"America/Grand_Turk", "America/Grenada", "America/Halifax", "America/Jamaica",
-				"America/Juneau", "America/Los_Angeles", "America/Lower_Princes", "America/Montserrat",
-				"America/Nassau", "America/New_York", "America/North_Dakota/Center",
-				"America/Phoenix", "America/Port_of_Spain", "America/Puerto_Rico",
-				"America/Regina", "America/Santo_Domingo", "America/St_Johns", "America/St_Kitts",
-				"America/St_Lucia", "America/St_Thomas", "America/St_Vincent", "America/Toronto",
-				"America/Tortola", "America/Vancouver", "America/Winnipeg", "Atlantic/Bermuda",
-				"Pacific/Guam", "Pacific/Honolulu", "Pacific/Pago_Pago", "Pacific/Saipan",
-			},
-		},
+		{num: "+17097264534", expectedTimeZones: []string{"America/St_Johns"}},
+		{num: "+6837000", expectedTimeZones: []string{"Pacific/Niue"}},
+		// A mobile number in a country where mobile numbers aren't geographically
+		// assigned is non-geographical, so it resolves at the country-calling-code
+		// level to all of the country's timezones.
+		{num: "+61491570156", expectedTimeZones: []string{
+			"Australia/Adelaide", "Australia/Brisbane", "Australia/Eucla", "Australia/Lord_Howe",
+			"Australia/Perth", "Australia/Sydney", "Indian/Christmas", "Indian/Cocos",
+		}},
 	}
 
 	for _, test := range tests {
-		timeZones, err := ForPrefix(test.num)
-		if err != nil {
-			t.Errorf("Failed to getTimezone for the number %s: %s", test.num, err)
-		}
-
-		if len(timeZones) == 0 {
-			t.Errorf("Expected at least 1 timezone.")
-		}
-
-		if !reflect.DeepEqual(timeZones, test.expectedTimeZones) {
-			t.Errorf("Expected '%v', got '%v' for '%s'", test.expectedTimeZones, timeZones, test.num)
-		}
-
 		num, err := phonenumbers.Parse(test.num, "")
 		if err != nil {
+			t.Errorf("Failed to parse number %s: %s", test.num, err)
 			continue
 		}
 
-		timeZones, err = ForNumber(num)
+		timeZones, err := TimeZonesForNumber(num)
 		if err != nil {
-			t.Errorf("Failed to getTimezone for the number %s: %s", num, err)
+			t.Errorf("Failed to get timezones for the number %s: %s", test.num, err)
 		}
-
 		if len(timeZones) == 0 {
-			t.Errorf("Expected at least 1 timezone.")
+			t.Errorf("Expected at least 1 timezone for %s.", test.num)
 		}
-
 		if !reflect.DeepEqual(timeZones, test.expectedTimeZones) {
-			t.Errorf("Expected '%v', got '%v' for '%s'", test.expectedTimeZones, timeZones, num)
+			t.Errorf("Expected '%v', got '%v' for '%s'", test.expectedTimeZones, timeZones, test.num)
 		}
+	}
+}
+
+// A number whose type can't be determined maps to the unknown timezone.
+func TestTimeZonesForNumberUnknownType(t *testing.T) {
+	num, err := phonenumbers.Parse("+1911", "")
+	if err != nil {
+		t.Fatalf("Failed to parse number: %s", err)
+	}
+	timeZones, err := TimeZonesForNumber(num)
+	if err != nil {
+		t.Fatalf("Failed to get timezones: %s", err)
+	}
+	if !reflect.DeepEqual(timeZones, []string{Unknown}) {
+		t.Errorf("Expected '%v', got '%v'", []string{Unknown}, timeZones)
+	}
+}
+
+// For a non-geographical mobile, the geographical lookup still resolves to the
+// specific area's timezone, unlike TimeZonesForNumber which gives the
+// country-level list.
+func TestTimeZonesForGeographicalNumber(t *testing.T) {
+	num, err := phonenumbers.Parse("+61491570156", "")
+	if err != nil {
+		t.Fatalf("Failed to parse number: %s", err)
+	}
+	timeZones, err := TimeZonesForGeographicalNumber(num)
+	if err != nil {
+		t.Fatalf("Failed to get timezones: %s", err)
+	}
+	if !reflect.DeepEqual(timeZones, []string{"Australia/Sydney"}) {
+		t.Errorf("Expected '%v', got '%v'", []string{"Australia/Sydney"}, timeZones)
 	}
 }


### PR DESCRIPTION
The `carrier`, `geocoding`, and `timezone` lookup subpackages had drifted from the upstream Java behaviour and exposed a leaner, differently-named API. This brings their behaviour and names back in line (baseline v9.0.31).

## Behaviour — now matches upstream
- **carrier.NameForNumber** applies Java's `isMobile` guard (`MOBILE` / `FIXED_LINE_OR_MOBILE` / `PAGER`) and returns `""` for other types, instead of returning a carrier name for any number type.
- **geocoding.DescriptionForNumber** branches like Java: `UNKNOWN` type → `""`; non-geographical → localized country name (with multi-region disambiguation); geographical → area description (including the Argentina-style mobile-token stripping).
- **timezone.TimeZonesForNumber** does Java's type-aware split: `UNKNOWN` → the unknown timezone; non-geographical → country-calling-code level; geographical → full-number lookup.
- **carrier + geocoding** no longer fall back to English when the requested language has no data — upstream returns `""` / the country name instead.

### ⚠️ Output changes
The timezone change alters results for two input classes, both now matching Java:
- A **non-geographical mobile** (e.g. `+61491570156`, an AU mobile) resolves at the country level to the country's full timezone list, not a single area zone.
- An **unknown-type** number (e.g. `+1911`) resolves to the unknown timezone.

Each delta was verified against the actual lookup data before updating test expectations.

## ⚠️ Breaking API changes (subpackage consumers)
Renamed to drop the Java `get` prefix while keeping the Java nouns, and added the upstream-public `*ForValidNumber` / `*ForGeographicalNumber` variants:

| Before | After |
|---|---|
| `carrier.ForNumber` | `carrier.NameForNumber` (+ `NameForValidNumber`) |
| `geocoding.ForNumber` | `geocoding.DescriptionForNumber` (+ `DescriptionForValidNumber`) |
| `timezone.ForNumber` | `timezone.TimeZonesForNumber` (+ `TimeZonesForGeographicalNumber`) |

Removed (no Java equivalent):
- `carrier.WithPrefixForNumber` — the matched-prefix length was a Go-only extra; lookup folded into `NameForValidNumber`.
- `timezone.ForPrefix(string)` — Java only takes a `PhoneNumber`; the prefix search is now an unexported helper.

`carrier.SafeDisplayName` and the `timezone.Unknown` const are unchanged.

## Notes
- SYNC.md records the remaining intentional divergence (dropped `Get` prefix, the `Unknown` const, and using `golang.org/x/text` for country names) so a future sync doesn't try to restore the `Get*` names.
- Verified: `gofmt` clean, `go build ./...`, `go vet ./...`, full `go test ./...` all pass. No stale references in README/docs/cmd.
- Still v2 — worth a release note given the renames/removals.