### PR TITLE
Restore Get prefix on carrier/geocoding/timezone exported names

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -27,9 +27,7 @@ Places where this port intentionally differs from upstream:
   `testGetMetadataForRegionForMissingMetadata` and its non-geographical variant (both rely on
   Mockito-style metadata-source injection), and `testRemovalNotSupported` (Go's range-over-func
   iterator has no `remove()`).
-- **Lookup-subpackage naming** — `carrier`, `geocoding`, and `timezone` keep the upstream
-  method *behaviour* but drop the Java `get` prefix (`getNameForNumber` → `carrier.NameForNumber`,
-  `getDescriptionForNumber` → `geocoding.DescriptionForNumber`, `getTimeZonesForNumber` →
-  `timezone.TimeZonesForNumber`), and `getUnknownTimeZone()` is the `timezone.Unknown` const.
+- **Lookup-subpackage details** — `carrier`, `geocoding`, and `timezone` mirror the upstream
+  `Get*` method names and behaviour, with two intentional shape differences:
+  `getUnknownTimeZone()` is exposed as the `timezone.Unknown` const rather than a function, and
   `geocoding` renders the country name via `golang.org/x/text` rather than `java.util.Locale`.
-  Don't "restore" the `Get` prefix on a sync.

--- a/carrier/carrier.go
+++ b/carrier/carrier.go
@@ -13,34 +13,34 @@ var carrierData embed.FS
 
 var mapper = prefixmapper.New(carrierData, "data")
 
-// NameForValidNumber returns the carrier we believe the number belongs to. Note
+// GetNameForValidNumber returns the carrier we believe the number belongs to. Note
 // due to number porting this is only a guess; there is no guarantee of its
 // accuracy. The number is assumed to be valid.
-func NameForValidNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+func GetNameForValidNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
 	e164 := phonenumbers.Format(number, phonenumbers.E164)
 	name, _, err := mapper.ValueForNumber(lang, 10, e164)
 	return name, err
 }
 
-// NameForNumber returns the carrier we believe the number belongs to. Note due
+// GetNameForNumber returns the carrier we believe the number belongs to. Note due
 // to number porting this is only a guess; there is no guarantee of its accuracy.
 // A carrier name is only returned for numbers of a mobile type.
-func NameForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+func GetNameForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
 	if isMobile(phonenumbers.GetNumberType(number)) {
-		return NameForValidNumber(number, lang)
+		return GetNameForValidNumber(number, lang)
 	}
 	return "", nil
 }
 
-// SafeDisplayName gets the name of the carrier for the given phone number only
+// GetSafeDisplayName gets the name of the carrier for the given phone number only
 // when it is 'safe' to display to users. A carrier name is considered safe if
 // the number is valid and for a region that doesn't support mobile number
 // portability.
-func SafeDisplayName(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+func GetSafeDisplayName(number *phonenumbers.PhoneNumber, lang string) (string, error) {
 	if phonenumbers.IsMobileNumberPortableRegion(phonenumbers.GetRegionCodeForNumber(number)) {
 		return "", nil
 	}
-	return NameForNumber(number, lang)
+	return GetNameForNumber(number, lang)
 }
 
 // isMobile reports whether numberType is a mobile type that a carrier can be

--- a/carrier/carrier_test.go
+++ b/carrier/carrier_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nyaruka/phonenumbers/v2"
 )
 
-func TestNameForNumber(t *testing.T) {
+func TestGetNameForNumber(t *testing.T) {
 	tests := []struct {
 		num      string
 		lang     string
@@ -30,7 +30,7 @@ func TestNameForNumber(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to parse number %s: %s", test.num, err)
 		}
-		carrier, err := NameForNumber(number, test.lang)
+		carrier, err := GetNameForNumber(number, test.lang)
 		if err != nil {
 			t.Errorf("Failed to get carrier for the number %s: %s", test.num, err)
 		}
@@ -40,7 +40,7 @@ func TestNameForNumber(t *testing.T) {
 	}
 }
 
-func TestNameForNumberConcurrency(t *testing.T) {
+func TestGetNameForNumberConcurrency(t *testing.T) {
 	number, _ := phonenumbers.Parse("+8613702032331", "ZZ")
 
 	wg := sync.WaitGroup{}
@@ -49,7 +49,7 @@ func TestNameForNumberConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := NameForNumber(number, "en")
+			_, err := GetNameForNumber(number, "en")
 			if err != nil {
 				t.Errorf("Failed to get carrier for the number %s: %s", "+8613702032331", err)
 			}
@@ -59,7 +59,7 @@ func TestNameForNumberConcurrency(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSafeDisplayName(t *testing.T) {
+func TestGetSafeDisplayName(t *testing.T) {
 	tests := []struct {
 		num      string
 		lang     string
@@ -73,9 +73,9 @@ func TestSafeDisplayName(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to parse number %s: %s", test.num, err)
 		}
-		carrier, err := SafeDisplayName(number, test.lang)
+		carrier, err := GetSafeDisplayName(number, test.lang)
 		if err != nil {
-			t.Errorf("Failed to SafeDisplayName for the number %s: %s", test.num, err)
+			t.Errorf("Failed to GetSafeDisplayName for the number %s: %s", test.num, err)
 		}
 		if test.expected != carrier {
 			t.Errorf("Expected '%s', got '%s' for '%s'", test.expected, carrier, test.num)
@@ -83,11 +83,11 @@ func TestSafeDisplayName(t *testing.T) {
 	}
 }
 
-func BenchmarkNameForNumber(b *testing.B) {
+func BenchmarkGetNameForNumber(b *testing.B) {
 	number, _ := phonenumbers.Parse("+8613702032331", "ZZ")
 
 	for n := 0; n < b.N; n++ {
-		_, err := NameForNumber(number, "en")
+		_, err := GetNameForNumber(number, "en")
 		if err != nil {
 			b.Errorf("Failed to get carrier for the number %s: %s", "+8613702032331", err)
 		}

--- a/geocoding/geocoding.go
+++ b/geocoding/geocoding.go
@@ -16,10 +16,10 @@ var geocodingData embed.FS
 
 var mapper = prefixmapper.New(geocodingData, "data")
 
-// DescriptionForValidNumber returns a text description in the given language for
+// GetDescriptionForValidNumber returns a text description in the given language for
 // the geographical area the number is from, falling back to the country name.
 // The number is assumed to be valid.
-func DescriptionForValidNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+func GetDescriptionForValidNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
 	mobileToken := phonenumbers.GetCountryMobileToken(int(number.GetCountryCode()))
 	nationalNumber := phonenumbers.GetNationalSignificantNumber(number)
 
@@ -44,18 +44,18 @@ func DescriptionForValidNumber(number *phonenumbers.PhoneNumber, lang string) (s
 	return countryNameForNumber(number, lang)
 }
 
-// DescriptionForNumber returns a text description in the given language for the
+// GetDescriptionForNumber returns a text description in the given language for the
 // given phone number: the name of the geographical area it is from for
 // geographical numbers, otherwise the name of the country, and the empty string
 // for numbers of an unknown type.
-func DescriptionForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
+func GetDescriptionForNumber(number *phonenumbers.PhoneNumber, lang string) (string, error) {
 	numberType := phonenumbers.GetNumberType(number)
 	if numberType == phonenumbers.UNKNOWN {
 		return "", nil
 	} else if !phonenumbers.IsNumberGeographicalForType(numberType, int(number.GetCountryCode())) {
 		return countryNameForNumber(number, lang)
 	}
-	return DescriptionForValidNumber(number, lang)
+	return GetDescriptionForValidNumber(number, lang)
 }
 
 // countryNameForNumber returns the name of the country, in the given language,

--- a/geocoding/geocoding_test.go
+++ b/geocoding/geocoding_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nyaruka/phonenumbers/v2"
 )
 
-func TestDescriptionForNumber(t *testing.T) {
+func TestGetDescriptionForNumber(t *testing.T) {
 	tests := []struct {
 		num      string
 		lang     string
@@ -28,7 +28,7 @@ func TestDescriptionForNumber(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to parse number %s: %s", test.num, err)
 		}
-		geocoding, err := DescriptionForNumber(number, test.lang)
+		geocoding, err := GetDescriptionForNumber(number, test.lang)
 		if err != nil {
 			t.Errorf("Failed to get description for the number %s: %s", test.num, err)
 		}

--- a/timezone/timezone.go
+++ b/timezone/timezone.go
@@ -15,8 +15,10 @@ import (
 //go:embed data/prefix_to_timezone.xml.gz
 var timezoneData []byte
 
-// Unknown is the value returned for a prefix that maps to no timezone. This is
-// defined by ICU as the unknown time zone.
+// Unknown is the value returned for a prefix that maps to no timezone, defined
+// by ICU as the unknown time zone. It corresponds to upstream's
+// PhoneNumberToTimeZonesMapper.getUnknownTimeZone(), exposed here as a const
+// rather than a function.
 const Unknown = "Etc/Unknown"
 
 var (
@@ -24,23 +26,23 @@ var (
 	timezoneMap  *serialize.IntStringArrayMap
 )
 
-// TimeZonesForNumber returns the names of the timezones to which the given
+// GetTimeZonesForNumber returns the names of the timezones to which the given
 // number maps. An unknown-type number maps to the unknown timezone; a
 // non-geographical number is resolved at the country-calling-code level; any
 // other number is resolved from its full digits.
-func TimeZonesForNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
+func GetTimeZonesForNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
 	numberType := phonenumbers.GetNumberType(number)
 	if numberType == phonenumbers.UNKNOWN {
 		return []string{Unknown}, nil
 	} else if !phonenumbers.IsNumberGeographicalForType(numberType, int(number.GetCountryCode())) {
 		return countryLevelTimeZonesForNumber(number)
 	}
-	return TimeZonesForGeographicalNumber(number)
+	return GetTimeZonesForGeographicalNumber(number)
 }
 
-// TimeZonesForGeographicalNumber returns the names of the timezones to which the
+// GetTimeZonesForGeographicalNumber returns the names of the timezones to which the
 // given geographical number maps, resolved from its full digits.
-func TimeZonesForGeographicalNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
+func GetTimeZonesForGeographicalNumber(number *phonenumbers.PhoneNumber) ([]string, error) {
 	e164 := phonenumbers.Format(number, phonenumbers.E164)
 	return lookupTimeZones(e164)
 }

--- a/timezone/timezone_test.go
+++ b/timezone/timezone_test.go
@@ -12,7 +12,7 @@ type timeZonesTestCases struct {
 	expectedTimeZones []string
 }
 
-func TestTimeZonesForNumber(t *testing.T) {
+func TestGetTimeZonesForNumber(t *testing.T) {
 	tests := []timeZonesTestCases{
 		{num: "+442073238299", expectedTimeZones: []string{"Europe/London"}},
 		{num: "+61255501234", expectedTimeZones: []string{"Australia/Sydney"}},
@@ -47,7 +47,7 @@ func TestTimeZonesForNumber(t *testing.T) {
 			continue
 		}
 
-		timeZones, err := TimeZonesForNumber(num)
+		timeZones, err := GetTimeZonesForNumber(num)
 		if err != nil {
 			t.Errorf("Failed to get timezones for the number %s: %s", test.num, err)
 		}
@@ -61,12 +61,12 @@ func TestTimeZonesForNumber(t *testing.T) {
 }
 
 // A number whose type can't be determined maps to the unknown timezone.
-func TestTimeZonesForNumberUnknownType(t *testing.T) {
+func TestGetTimeZonesForNumberUnknownType(t *testing.T) {
 	num, err := phonenumbers.Parse("+1911", "")
 	if err != nil {
 		t.Fatalf("Failed to parse number: %s", err)
 	}
-	timeZones, err := TimeZonesForNumber(num)
+	timeZones, err := GetTimeZonesForNumber(num)
 	if err != nil {
 		t.Fatalf("Failed to get timezones: %s", err)
 	}
@@ -76,14 +76,14 @@ func TestTimeZonesForNumberUnknownType(t *testing.T) {
 }
 
 // For a non-geographical mobile, the geographical lookup still resolves to the
-// specific area's timezone, unlike TimeZonesForNumber which gives the
+// specific area's timezone, unlike GetTimeZonesForNumber which gives the
 // country-level list.
-func TestTimeZonesForGeographicalNumber(t *testing.T) {
+func TestGetTimeZonesForGeographicalNumber(t *testing.T) {
 	num, err := phonenumbers.Parse("+61491570156", "")
 	if err != nil {
 		t.Fatalf("Failed to parse number: %s", err)
 	}
-	timeZones, err := TimeZonesForGeographicalNumber(num)
+	timeZones, err := GetTimeZonesForGeographicalNumber(num)
 	if err != nil {
 		t.Fatalf("Failed to get timezones: %s", err)
 	}


### PR DESCRIPTION
A recent change dropped the Java `get` prefix from the three lookup subpackages (`carrier.NameForNumber`, `geocoding.DescriptionForNumber`, `timezone.TimeZonesForNumber`, …). An audit of the public API showed those 8 methods became the **only** ones in the library that drop it: every other hand-ported method (`PhoneNumberUtil`, `ShortNumberInfo`, `AsYouTypeFormatter`) and every protoc-generated getter keeps `Get` to mirror upstream Java verbatim. This brings the subpackages back in line.

**Naming only** — the behaviour fixes and the `WithPrefixForNumber` / `ForPrefix` removals from the previous PR are untouched.

## Renamed
| Before | After |
|---|---|
| `carrier.NameForNumber` / `NameForValidNumber` / `SafeDisplayName` | `carrier.GetNameForNumber` / `GetNameForValidNumber` / `GetSafeDisplayName` |
| `geocoding.DescriptionForNumber` / `DescriptionForValidNumber` | `geocoding.GetDescriptionForNumber` / `GetDescriptionForValidNumber` |
| `timezone.TimeZonesForNumber` / `TimeZonesForGeographicalNumber` | `timezone.GetTimeZonesForNumber` / `GetTimeZonesForGeographicalNumber` |

## Kept as-is
- **`timezone.Unknown`** stays a const (better Go shape than a `getUnknownTimeZone()` function); its doc now notes it corresponds to upstream's `getUnknownTimeZone()`.
- **SYNC.md** divergence note corrected — it previously said to *drop* the `Get` prefix, the opposite of this change. It now records that the subpackages mirror the upstream `Get*` names, leaving only the `Unknown` const and the `golang.org/x/text` country-name rendering as intentional shape differences.

## Reviewer notes
- Breaking for consumers who adopted the (brief, unreleased-in-a-tag) dropped-`Get` names. Pairs with the previous subpackage PR — worth bundling into the same release note.
- Verified: `gofmt` clean, `go build ./...`, `go vet ./...`, full `go test ./...` pass; no stale references in code, README, docs, or cmd.