### PR TITLE
Close remaining public-API gaps with upstream Java

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -81,11 +81,11 @@ type ValidationResult int
 
 const (
 	IS_POSSIBLE ValidationResult = iota
+	IS_POSSIBLE_LOCAL_ONLY
 	INVALID_COUNTRY_CODE
 	TOO_SHORT
-	TOO_LONG
-	IS_POSSIBLE_LOCAL_ONLY
 	INVALID_LENGTH
+	TOO_LONG
 )
 
 // TODO(ttacon): leniency comments?
@@ -105,36 +105,36 @@ func (l Leniency) Verify(number *PhoneNumber, candidate string) bool {
 		return IsPossibleNumber(number)
 	case VALID:
 		if !IsValidNumber(number) ||
-			!ContainsOnlyValidXChars(number, candidate) {
+			!containsOnlyValidXChars(number, candidate) {
 			return false
 		}
-		return IsNationalPrefixPresentIfRequired(number)
+		return isNationalPrefixPresentIfRequired(number)
 	case STRICT_GROUPING:
 		if !IsValidNumber(number) ||
-			!ContainsOnlyValidXChars(number, candidate) ||
-			ContainsMoreThanOneSlashInNationalNumber(number, candidate) ||
-			!IsNationalPrefixPresentIfRequired(number) {
+			!containsOnlyValidXChars(number, candidate) ||
+			containsMoreThanOneSlashInNationalNumber(number, candidate) ||
+			!isNationalPrefixPresentIfRequired(number) {
 			return false
 		}
-		return CheckNumberGroupingIsValid(number, candidate,
+		return checkNumberGroupingIsValid(number, candidate,
 			func(number *PhoneNumber,
 				normalizedCandidate string,
 				expectedNumberGroups []string) bool {
-				return AllNumberGroupsRemainGrouped(
+				return allNumberGroupsRemainGrouped(
 					number, normalizedCandidate, expectedNumberGroups)
 			})
 	case EXACT_GROUPING:
 		if !IsValidNumber(number) ||
-			!ContainsOnlyValidXChars(number, candidate) ||
-			ContainsMoreThanOneSlashInNationalNumber(number, candidate) ||
-			!IsNationalPrefixPresentIfRequired(number) {
+			!containsOnlyValidXChars(number, candidate) ||
+			containsMoreThanOneSlashInNationalNumber(number, candidate) ||
+			!isNationalPrefixPresentIfRequired(number) {
 			return false
 		}
-		return CheckNumberGroupingIsValid(number, candidate,
+		return checkNumberGroupingIsValid(number, candidate,
 			func(number *PhoneNumber,
 				normalizedCandidate string,
 				expectedNumberGroups []string) bool {
-				return AllNumberGroupsAreExactlyPresent(
+				return allNumberGroupsAreExactlyPresent(
 					number, normalizedCandidate, expectedNumberGroups)
 			})
 	}

--- a/geocoding/geocoding.go
+++ b/geocoding/geocoding.go
@@ -44,6 +44,31 @@ func GetDescriptionForValidNumber(number *phonenumbers.PhoneNumber, lang string)
 	return countryNameForNumber(number, lang)
 }
 
+// GetDescriptionForValidNumberForUserRegion is as per GetDescriptionForValidNumber but
+// also considers the region of the user. If the phone number is from the same region as
+// the user, only a lower-level description will be returned, if one exists. Otherwise,
+// the phone number's region will be returned, with optionally some more detailed
+// information.
+//
+// For example, for a user from the region "US" (United States), we would show "Mountain
+// View, CA" for a particular number, omitting the United States from the description. For
+// a user from the United Kingdom (region "GB"), for the same number we may show "Mountain
+// View, CA, United States" or even just "United States". The number is assumed to be
+// valid. userRegion should be a two-letter upper-case CLDR region code.
+func GetDescriptionForValidNumberForUserRegion(number *phonenumbers.PhoneNumber, lang string, userRegion string) (string, error) {
+	// If the user region matches the number's region, then we just show the lower-level
+	// description, if one exists - if no description exists, we will show the region(country)
+	// name for the number.
+	regionCode := phonenumbers.GetRegionCodeForNumber(number)
+	if userRegion == regionCode {
+		return GetDescriptionForValidNumber(number, lang)
+	}
+	// Otherwise, we just show the region(country) name for now.
+	return regionDisplayName(regionCode, lang), nil
+	// TODO: Concatenate the lower-level and country-name information in an appropriate
+	// way for each language.
+}
+
 // GetDescriptionForNumber returns a text description in the given language for the
 // given phone number: the name of the geographical area it is from for
 // geographical numbers, otherwise the name of the country, and the empty string
@@ -56,6 +81,18 @@ func GetDescriptionForNumber(number *phonenumbers.PhoneNumber, lang string) (str
 		return countryNameForNumber(number, lang)
 	}
 	return GetDescriptionForValidNumber(number, lang)
+}
+
+// GetDescriptionForNumberForUserRegion is as per GetDescriptionForValidNumberForUserRegion
+// but explicitly checks the validity of the number passed in.
+func GetDescriptionForNumberForUserRegion(number *phonenumbers.PhoneNumber, lang string, userRegion string) (string, error) {
+	numberType := phonenumbers.GetNumberType(number)
+	if numberType == phonenumbers.UNKNOWN {
+		return "", nil
+	} else if !phonenumbers.IsNumberGeographicalForType(numberType, int(number.GetCountryCode())) {
+		return countryNameForNumber(number, lang)
+	}
+	return GetDescriptionForValidNumberForUserRegion(number, lang, userRegion)
 }
 
 // countryNameForNumber returns the name of the country, in the given language,

--- a/geocoding/geocoding_test.go
+++ b/geocoding/geocoding_test.go
@@ -37,3 +37,36 @@ func TestGetDescriptionForNumber(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDescriptionForNumberForUserRegion(t *testing.T) {
+	tests := []struct {
+		num        string
+		lang       string
+		userRegion string
+		expected   string
+	}{
+		// User in the same region as the number: detailed area description.
+		{num: "+16193165996", lang: "en", userRegion: "US", expected: "California"},
+		// User in a different region: just the country name, in the requested language,
+		// without the more detailed area information.
+		{num: "+16193165996", lang: "en", userRegion: "GB", expected: "United States"},
+		{num: "+16193165996", lang: "es", userRegion: "IT", expected: "Estados Unidos"},
+		// Unknown user region: just show the country name.
+		{num: "+16193165996", lang: "es", userRegion: "ZZ", expected: "Estados Unidos"},
+		// Invalid number: empty string.
+		{num: "+1123456789", lang: "en", userRegion: "US", expected: ""},
+	}
+	for _, test := range tests {
+		number, err := phonenumbers.Parse(test.num, "ZZ")
+		if err != nil {
+			t.Errorf("Failed to parse number %s: %s", test.num, err)
+		}
+		geocoding, err := GetDescriptionForNumberForUserRegion(number, test.lang, test.userRegion)
+		if err != nil {
+			t.Errorf("Failed to get description for the number %s: %s", test.num, err)
+		}
+		if test.expected != geocoding {
+			t.Errorf("Expected '%s', got '%s' for '%s' (userRegion %s)", test.expected, geocoding, test.num, test.userRegion)
+		}
+	}
+}

--- a/phonenumbermatcher.go
+++ b/phonenumbermatcher.go
@@ -332,10 +332,10 @@ func getNationalNumberGroupsWithPattern(number *PhoneNumber, formattingPattern *
 	return strings.Split(formatNsnUsingPattern(nationalSignificantNumber, formattingPattern, RFC3966), "-")
 }
 
-// CheckNumberGroupingIsValid checks the digit groups of candidate against the
+// checkNumberGroupingIsValid checks the digit groups of candidate against the
 // expected grouping for number using checker, falling back to any alternate
 // formats for the number's country calling code.
-func CheckNumberGroupingIsValid(
+func checkNumberGroupingIsValid(
 	number *PhoneNumber,
 	candidate string,
 	checker func(number *PhoneNumber, normalizedCandidate string, expectedNumberGroups []string) bool) bool {
@@ -367,10 +367,10 @@ func CheckNumberGroupingIsValid(
 	return false
 }
 
-// AllNumberGroupsRemainGrouped reports that the number groups found in the
+// allNumberGroupsRemainGrouped reports that the number groups found in the
 // candidate are not broken up differently from how the number would be
 // formatted (the STRICT_GROUPING check).
-func AllNumberGroupsRemainGrouped(
+func allNumberGroupsRemainGrouped(
 	number *PhoneNumber,
 	normalizedCandidate string,
 	formattedNumberGroups []string) bool {
@@ -415,10 +415,10 @@ func AllNumberGroupsRemainGrouped(
 	return strings.Contains(normalizedCandidate[fromIndex:], number.GetExtension())
 }
 
-// AllNumberGroupsAreExactlyPresent reports that the groups of digits in the
+// allNumberGroupsAreExactlyPresent reports that the groups of digits in the
 // candidate exactly match how the number would be formatted (the EXACT_GROUPING
 // check).
-func AllNumberGroupsAreExactlyPresent(
+func allNumberGroupsAreExactlyPresent(
 	number *PhoneNumber,
 	normalizedCandidate string,
 	formattedNumberGroups []string) bool {
@@ -467,9 +467,9 @@ func splitNonDigits(s string) []string {
 	return groups
 }
 
-// ContainsMoreThanOneSlashInNationalNumber reports whether candidate contains
+// containsMoreThanOneSlashInNationalNumber reports whether candidate contains
 // more than one slash in the national-number portion (used to reject dates).
-func ContainsMoreThanOneSlashInNationalNumber(number *PhoneNumber, candidate string) bool {
+func containsMoreThanOneSlashInNationalNumber(number *PhoneNumber, candidate string) bool {
 	firstSlashInBodyIndex := strings.IndexByte(candidate, '/')
 	if firstSlashInBodyIndex < 0 {
 		// No slashes, this is okay.
@@ -494,9 +494,9 @@ func ContainsMoreThanOneSlashInNationalNumber(number *PhoneNumber, candidate str
 	return true
 }
 
-// ContainsOnlyValidXChars reports whether every 'x'/'X' in candidate represents
+// containsOnlyValidXChars reports whether every 'x'/'X' in candidate represents
 // a carrier code or an extension sign (and not, say, a vanity-number letter).
-func ContainsOnlyValidXChars(number *PhoneNumber, candidate string) bool {
+func containsOnlyValidXChars(number *PhoneNumber, candidate string) bool {
 	// The characters 'x' and 'X' can be (1) a carrier code, in which case they
 	// always precede the national significant number or (2) an extension sign,
 	// in which case they always precede the extension number. We assume a
@@ -524,9 +524,9 @@ func ContainsOnlyValidXChars(number *PhoneNumber, candidate string) bool {
 	return true
 }
 
-// IsNationalPrefixPresentIfRequired reports whether, if a national prefix is
+// isNationalPrefixPresentIfRequired reports whether, if a national prefix is
 // required to format number, it was present in the raw input.
-func IsNationalPrefixPresentIfRequired(number *PhoneNumber) bool {
+func isNationalPrefixPresentIfRequired(number *PhoneNumber) bool {
 	// First, check how we deduced the country code. If it was written in
 	// international format, then the national prefix is not required.
 	if number.GetCountryCodeSource() != PhoneNumber_FROM_DEFAULT_COUNTRY {

--- a/phonenumbermatcher_test.go
+++ b/phonenumbermatcher_test.go
@@ -77,26 +77,26 @@ func TestContainsMoreThanOneSlashInNationalNumber(t *testing.T) {
 	useTestMetadata(t)
 	// A date should return true.
 	number := &PhoneNumber{CountryCode: proto.Int32(1), CountryCodeSource: ccSource(PhoneNumber_FROM_DEFAULT_COUNTRY)}
-	assert.True(t, ContainsMoreThanOneSlashInNationalNumber(number, "1/05/2013"))
+	assert.True(t, containsMoreThanOneSlashInNationalNumber(number, "1/05/2013"))
 
 	// The country code source thinks it started with a country calling code, but
 	// this is not the same as the part before the slash, so it's still true.
 	number = &PhoneNumber{CountryCode: proto.Int32(274), CountryCodeSource: ccSource(PhoneNumber_FROM_NUMBER_WITHOUT_PLUS_SIGN)}
-	assert.True(t, ContainsMoreThanOneSlashInNationalNumber(number, "27/4/2013"))
+	assert.True(t, containsMoreThanOneSlashInNationalNumber(number, "27/4/2013"))
 
 	// Now false, because the first slash is after the country calling code.
 	number = &PhoneNumber{CountryCode: proto.Int32(49), CountryCodeSource: ccSource(PhoneNumber_FROM_NUMBER_WITH_PLUS_SIGN)}
-	assert.False(t, ContainsMoreThanOneSlashInNationalNumber(number, "49/69/2013"))
+	assert.False(t, containsMoreThanOneSlashInNationalNumber(number, "49/69/2013"))
 
 	number = &PhoneNumber{CountryCode: proto.Int32(49), CountryCodeSource: ccSource(PhoneNumber_FROM_NUMBER_WITHOUT_PLUS_SIGN)}
-	assert.False(t, ContainsMoreThanOneSlashInNationalNumber(number, "+49/69/2013"))
-	assert.False(t, ContainsMoreThanOneSlashInNationalNumber(number, "+ 49/69/2013"))
-	assert.True(t, ContainsMoreThanOneSlashInNationalNumber(number, "+ 49/69/20/13"))
+	assert.False(t, containsMoreThanOneSlashInNationalNumber(number, "+49/69/2013"))
+	assert.False(t, containsMoreThanOneSlashInNationalNumber(number, "+ 49/69/2013"))
+	assert.True(t, containsMoreThanOneSlashInNationalNumber(number, "+ 49/69/20/13"))
 
 	// Here the first group is not assumed to be the country calling code, even
 	// though it is the same as it, so this should return true.
 	number = &PhoneNumber{CountryCode: proto.Int32(49), CountryCodeSource: ccSource(PhoneNumber_FROM_DEFAULT_COUNTRY)}
-	assert.True(t, ContainsMoreThanOneSlashInNationalNumber(number, "49/69/2013"))
+	assert.True(t, containsMoreThanOneSlashInNationalNumber(number, "49/69/2013"))
 }
 
 func TestFindNationalNumber(t *testing.T) {


### PR DESCRIPTION
Follow-ups from comparing this port's public API against libphonenumber's Java reference (v9.0.31), beyond the overload-suffix renames already done in prior PRs.

## Changes

### 1. geocoding: port the missing `userRegion` overloads
Java's `PhoneNumberOfflineGeocoder` exposes four public methods; we only had two. Added:
- `GetDescriptionForValidNumberForUserRegion(number, lang, userRegion)`
- `GetDescriptionForNumberForUserRegion(number, lang, userRegion)`

These omit the country from the description when the number is from the same region as the caller (e.g. "California" for a US caller vs "United States" for a GB caller), otherwise returning the localized country name. Ported the upstream `testGetDescriptionForNumberWithUserRegion` case, adapted to the production geocoding data.

**New public API** — note the `…ForUserRegion` suffix naming for the Java overloads.

### 2. phonenumbermatcher: unexport six helpers
`checkNumberGroupingIsValid`, `allNumberGroupsRemainGrouped`, `allNumberGroupsAreExactlyPresent`, `containsMoreThanOneSlashInNationalNumber`, `containsOnlyValidXChars`, `isNationalPrefixPresentIfRequired` are package-private in Java and only used internally by `Leniency.Verify`. They were exported here but never part of Java's public surface.

**Breaking** for any external caller that imported these — they are no longer exported.

### 3. enums: reorder `ValidationResult` to match Java ordinals
New order: `IS_POSSIBLE, IS_POSSIBLE_LOCAL_ONLY, INVALID_COUNTRY_CODE, TOO_SHORT, INVALID_LENGTH, TOO_LONG`. Comparisons are identity-based throughout, so behaviour is unchanged; this only aligns the constants' integer values with the Java enum.

## Notes
None of these introduce new divergences from upstream, so `SYNC.md` and the reconciled-against version (`v9.0.31`) are unchanged.

## Testing
`go build ./...`, `go vet ./...`, `gofmt`, and `go test ./...` all pass.