### PR TITLE
Guard against out-of-range slice in national number parsing

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -27,6 +27,11 @@ Places where this port intentionally differs from upstream:
   `testGetMetadataForRegionForMissingMetadata` and its non-geographical variant (both rely on
   Mockito-style metadata-source injection), and `testRemovalNotSupported` (Go's range-over-func
   iterator has no `remove()`).
+- **Defensive slice bounds in `buildNationalNumberForParsing`** — the national number is taken
+  from the substring between a leading `tel:` and `;phone-context=`; we only treat `tel:` as the
+  start marker when it precedes the phone-context, keeping the substring bounds well-ordered on
+  arbitrary input. This is a robustness guard for Go's slice semantics — preserve it across syncs
+  rather than reconciling it away.
 - **Lookup-subpackage details** — `carrier`, `geocoding`, and `timezone` mirror the upstream
   `Get*` method names and behaviour, with two intentional shape differences:
   `getUnknownTimeZone()` is exposed as the `timezone.Unknown` const rather than a function, and

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2940,9 +2940,13 @@ func buildNationalNumberForParsing(
 		// the national number, an optional extension or isdn-subaddress component. Note we also
 		// handle the case when "tel:" is missing, as we have seen in some of the phone number inputs.
 		// In that case, we append everything from the beginning.
+		// Only honor the "tel:" prefix when it actually appears before the
+		// phone-context. A "tel:" occurring after it is part of a trailing
+		// parameter and must be ignored, otherwise the slice below could have a
+		// start index greater than its end index.
 		indexOfRfc3966Prefix := strings.Index(numberToParse, rfc3966Prefix)
 		indexOfNationalNumber := 0
-		if indexOfRfc3966Prefix >= 0 {
+		if indexOfRfc3966Prefix >= 0 && indexOfRfc3966Prefix < indexOfPhoneContext {
 			indexOfNationalNumber = indexOfRfc3966Prefix + len(rfc3966Prefix)
 		}
 		nationalNumber.WriteString(numberToParse[indexOfNationalNumber:indexOfPhoneContext])

--- a/phonenumberutil_internal_test.go
+++ b/phonenumberutil_internal_test.go
@@ -276,6 +276,21 @@ func TestFormattingRuleHasFirstGroupOnly(t *testing.T) {
 	assert.False(t, formattingRuleHasFirstGroupOnly("$1 suffix"))
 }
 
+// TestParseNoPanicWithTelAfterPhoneContext is a regression test for
+// GHSA-374v-j3m9-frpm: when "tel:" appears after a valid ";phone-context=",
+// buildNationalNumberForParsing used to slice with a start index past its end
+// and panic. Parse must return an error instead of crashing.
+func TestParseNoPanicWithTelAfterPhoneContext(t *testing.T) {
+	for _, in := range []string{
+		"5;phone-context=+1;tel:x",
+		"5;phone-context=+49;foo=tel:",
+	} {
+		assert.NotPanics(t, func() {
+			_, _ = Parse(in, "US")
+		}, "input %q", in)
+	}
+}
+
 func BenchmarkLoadMetadata(b *testing.B) {
 	for i := 0; i <= b.N; i++ {
 		_, _ = metadata.Load()


### PR DESCRIPTION
## What

`Parse` (and the other entry points that route through `parseHelper` → `buildNationalNumberForParsing`) could panic with a `slice bounds out of range` error on malformed RFC3966-style input where a `tel:` marker appears *after* `;phone-context=`, e.g. `5;phone-context=+1;tel:x`.

The national number is taken from the substring between a leading `tel:` and `;phone-context=`. The two markers were located with independent `strings.Index` calls, so when `tel:` occurred after the phone-context the start index could exceed the end index, panicking on the slice.

## Fix

Only treat `tel:` as the start marker when it actually precedes `;phone-context=`; otherwise fall back to the beginning of the string (the existing "no `tel:` prefix" behaviour). This keeps the substring bounds well-ordered on arbitrary input.

## Notes for reviewers

- Adds a regression test (`TestParseNoPanicWithTelAfterPhoneContext`) covering the malformed inputs.
- Records the guard in `SYNC.md` so it's preserved across future upstream syncs.
- Full test suite passes.