### PR TITLE
Clamp leading-zero count before allocating national significant number

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -32,6 +32,11 @@ Places where this port intentionally differs from upstream:
   start marker when it precedes the phone-context, keeping the substring bounds well-ordered on
   arbitrary input. This is a robustness guard for Go's slice semantics — preserve it across syncs
   rather than reconciling it away.
+- **Clamped leading-zero allocation in `GetNationalSignificantNumber`** — the leading-zero count
+  is taken from the `PhoneNumber.NumberOfLeadingZeros` field, which is an unbounded `int32` when a
+  message is populated from outside `Parse`. We clamp it to `maxLengthForNSN` before allocating,
+  since a national significant number cannot have more leading zeros than its maximum length. This
+  is a robustness guard on the allocation size — preserve it across syncs.
 - **Lookup-subpackage details** — `carrier`, `geocoding`, and `timezone` mirror the upstream
   `Get*` method names and behaviour, with two intentional shape differences:
   `getUnknownTimeZone()` is exposed as the `timezone.Unknown` const rather than a function, and

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -1503,7 +1503,16 @@ func GetNationalSignificantNumber(number *PhoneNumber) string {
 	// Guard GetNumberOfLeadingZeros() > 0 to match upstream and to avoid a
 	// make([]byte, n) panic on a negative count (an invalid but possible input).
 	if number.GetItalianLeadingZero() && number.GetNumberOfLeadingZeros() > 0 {
-		zeros := make([]byte, number.GetNumberOfLeadingZeros())
+		// Clamp to maxLengthForNSN before allocating: a legitimate national
+		// significant number can never have more leading zeros than its maximum
+		// total length. The field is an int32 that can carry an arbitrary
+		// attacker-controlled value when a PhoneNumber is populated from an
+		// untrusted source rather than produced by Parse, so bound it here.
+		numLeadingZeros := int(number.GetNumberOfLeadingZeros())
+		if numLeadingZeros > maxLengthForNSN {
+			numLeadingZeros = maxLengthForNSN
+		}
+		zeros := make([]byte, numLeadingZeros)
 		for i := range zeros {
 			zeros[i] = '0'
 		}

--- a/phonenumberutil_internal_test.go
+++ b/phonenumberutil_internal_test.go
@@ -291,6 +291,23 @@ func TestParseNoPanicWithTelAfterPhoneContext(t *testing.T) {
 	}
 }
 
+// TestGetNationalSignificantNumberClampsLeadingZeros is a regression test for
+// GHSA-4h7c-rcfg-mqmw: NumberOfLeadingZeros is an attacker-controllable int32
+// when a PhoneNumber crosses a trust boundary (e.g. protobuf from an untrusted
+// source), and it was used unbounded as an allocation size. The count must be
+// clamped to maxLengthForNSN so a hostile value cannot drive a huge allocation.
+func TestGetNationalSignificantNumberClampsLeadingZeros(t *testing.T) {
+	hostile := &PhoneNumber{
+		CountryCode:          proto.Int32(1),
+		NationalNumber:       proto.Uint64(6502530000),
+		ItalianLeadingZero:   proto.Bool(true),
+		NumberOfLeadingZeros: proto.Int32(1 << 30),
+	}
+	nsn := GetNationalSignificantNumber(hostile)
+	// maxLengthForNSN leading zeros plus the 10-digit national number.
+	assert.Len(t, nsn, maxLengthForNSN+len("6502530000"))
+}
+
 func BenchmarkLoadMetadata(b *testing.B) {
 	for i := 0; i <= b.N; i++ {
 		_, _ = metadata.Load()


### PR DESCRIPTION
## What

`GetNationalSignificantNumber` sized a byte-slice allocation directly from the `PhoneNumber.NumberOfLeadingZeros` field:

```go
zeros := make([]byte, number.GetNumberOfLeadingZeros())
```

That field is an unbounded `int32`. When a `*PhoneNumber` is produced by `Parse`, the value is always small (it's the count of literal `'0'` characters in input capped at `maxLengthForNSN`). But when a `PhoneNumber` is populated from outside `Parse` — e.g. decoded from a protobuf/JSON message that crosses a trust boundary — the field can carry any value up to `0x7fffffff`, driving a multi-GiB allocation from a tiny payload and exhausting memory.

`GetNationalSignificantNumber` is called transitively by `Format`, `FormatByPattern`, `IsValidNumber`, `GetNumberType`, `GetRegionCodeForNumber`, `IsPossibleNumber`, `GetTimezonesForNumber` and others, so any of those on an untrusted `*PhoneNumber` is affected.

## Fix

Clamp the leading-zero count to `maxLengthForNSN` before allocating. A national significant number cannot legitimately have more leading zeros than its maximum total length, so this preserves all valid behavior while bounding the allocation. The existing `> 0` guard (against a negative count) is retained.

## Notes for reviewers

- Adds a regression test (`TestGetNationalSignificantNumberClampsLeadingZeros`) asserting the output length is bounded when the field is set to a large value.
- Records the guard in `SYNC.md` so it's preserved across future upstream syncs.
- Full test suite passes.